### PR TITLE
Use the proper poetry syntax for referring to the metadata branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ python-dotenv = "^0.17.1"
 networkx = "^2.5.1"
 fastapi-cache2 = "^0.1.3"
 accept-types = "^0.4.1"
-isamples_metadata = {git = "git@github.com:isamplesorg/metadata.git", rev = "develop"}
+isamples_metadata = {git = "git@github.com:isamplesorg/metadata.git", branch = "develop"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.3"


### PR DESCRIPTION
Per discussion with @datadavev, update the poetry dependency to the correct syntax per https://python-poetry.org/docs/dependency-specification/