### PR TITLE
Don't attempt to fetch records if we've already reached the end and have cleared our next url

### DIFF
--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -88,7 +88,7 @@ class OpenContextRecordIterator(isb_lib.core.IdentifierIterator):
         }
         more_work = True
         num_records = 0
-        while more_work:
+        while more_work and self.url is not None:
             L.info("trying to hit %s", self.url)
             response = requests.get(
                 self.url, params=params, headers=headers, timeout=HTTP_TIMEOUT


### PR DESCRIPTION
Keep the superclass logic in place, just break out of iteration if we have a None url