### PR TITLE
Alternate identifiers

### DIFF
--- a/isb_lib/__init__.py
+++ b/isb_lib/__init__.py
@@ -1,9 +1,15 @@
 import json
 import datetime
+import typing
+import re
+
 
 JSON_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 """datetime format string for generating JSON content
 """
+
+n2t_regex = re.compile(r"https?://n2t\.net/")
+
 
 def datetimeToJsonStr(dt):
     """Convert datetime to a JSON compatible string"""
@@ -20,6 +26,11 @@ def _jsonConverter(o):
         return datetimeToJsonStr(o)
     return o.__str__()
 
+
 def jsonDumps(obj):
     """Dump object as JSON, handling date conversion"""
     return json.dumps(obj, indent=2, default=_jsonConverter, sort_keys=True)
+
+
+def normalized_id(raw_id: typing.AnyStr) -> typing.AnyStr:
+    return n2t_regex.sub("", raw_id)

--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -63,6 +63,13 @@ def initialize_logging(verbosity: typing.AnyStr):
     if verbosity not in LOG_LEVELS.keys():
         L.warning("%s is not a log level, set to INFO", verbosity)
 
+
+n2t_regex = re.compile(r"https?://n2t\.net/")
+
+
+def normalized_id(raw_id: typing.AnyStr) -> typing.AnyStr:
+    return n2t_regex.sub("", raw_id)
+
 def things_main(ctx, db_url, solr_url, verbosity, heart_rate):
     ctx.ensure_object(dict)
     initialize_logging(verbosity)

--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -64,11 +64,8 @@ def initialize_logging(verbosity: typing.AnyStr):
         L.warning("%s is not a log level, set to INFO", verbosity)
 
 
-n2t_regex = re.compile(r"https?://n2t\.net/")
 
 
-def normalized_id(raw_id: typing.AnyStr) -> typing.AnyStr:
-    return n2t_regex.sub("", raw_id)
 
 def things_main(ctx, db_url, solr_url, verbosity, heart_rate):
     ctx.ensure_object(dict)

--- a/isb_lib/models/thing.py
+++ b/isb_lib/models/thing.py
@@ -95,14 +95,17 @@ class Thing(SQLModel, table=True):
 
 class ThingIdentifier(SQLModel, table=True):
     guid: Optional[str] = Field(
-        primary_key=True, default=None, nullable=False, index=False, description="The String GUID"
+        primary_key=True,
+        default=None,
+        nullable=False,
+        index=False,
+        description="The String GUID",
     )
     tstamp: datetime = Field(
         default=igsn_lib.time.dtnow(),
         description="When the identifier was added to this database",
-        index=False
+        index=False,
     )
     thing_id: Optional[int] = Field(
-        default=None, nullable=False, foreign_key="thing._id",
-        index=False
+        default=None, nullable=False, foreign_key="thing._id", index=False
     )

--- a/isb_lib/models/thing.py
+++ b/isb_lib/models/thing.py
@@ -93,7 +93,7 @@ class Thing(SQLModel, table=True):
         return res
 
 
-class Identifier(SQLModel, table=True):
+class ThingIdentifier(SQLModel, table=True):
     guid: Optional[str] = Field(
         primary_key=True, default=None, nullable=False, index=True, description="The String GUID"
     )

--- a/isb_lib/models/thing.py
+++ b/isb_lib/models/thing.py
@@ -2,12 +2,9 @@ import igsn_lib.time
 import json
 from typing import Optional
 import typing
-from sqlmodel import Field, SQLModel, create_engine, Session, select
+from sqlmodel import Field, SQLModel
 from datetime import datetime
 import sqlalchemy
-import isb_web.config
-import click
-import click_config_file
 
 
 class Thing(SQLModel, table=True):
@@ -94,3 +91,16 @@ class Thing(SQLModel, table=True):
             "resolved_media_type": self.resolved_media_type,
         }
         return res
+
+
+class Identifier(SQLModel, table=True):
+    guid: Optional[str] = Field(
+        primary_key=True, default=None, nullable=False, index=True, description="The String GUID"
+    )
+    tstamp: datetime = Field(
+        default=igsn_lib.time.dtnow(),
+        description="When the identifier was added to this database",
+    )
+    thing_id: Optional[int] = Field(
+        default=None, nullable=False, foreign_key="thing._id"
+    )

--- a/isb_lib/models/thing.py
+++ b/isb_lib/models/thing.py
@@ -95,12 +95,14 @@ class Thing(SQLModel, table=True):
 
 class ThingIdentifier(SQLModel, table=True):
     guid: Optional[str] = Field(
-        primary_key=True, default=None, nullable=False, index=True, description="The String GUID"
+        primary_key=True, default=None, nullable=False, index=False, description="The String GUID"
     )
     tstamp: datetime = Field(
         default=igsn_lib.time.dtnow(),
         description="When the identifier was added to this database",
+        index=False
     )
     thing_id: Optional[int] = Field(
-        default=None, nullable=False, foreign_key="thing._id"
+        default=None, nullable=False, foreign_key="thing._id",
+        index=False
     )

--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -196,6 +196,7 @@ def load_thing(
     thing = item.as_thing(t_created, 200, url, t_resolved, None)
     return thing
 
+
 def update_thing(thing: isb_lib.models.thing.Thing, updated_record: typing.Dict, t_resolved: datetime.datetime, url: typing.AnyStr):
     """
     Updates an existing Thing row in the database

--- a/isb_lib/smithsonian_adapter.py
+++ b/isb_lib/smithsonian_adapter.py
@@ -1,18 +1,12 @@
 import typing
 import datetime
-import re
 
 import isamples_metadata.SmithsonianTransformer
 
 import isb_lib.core
 import logging
+
 from isb_lib.models.thing import Thing
-
-n2t_regex = re.compile(r"https?://n2t\.net/")
-
-
-def _normalized_id(raw_id: typing.AnyStr) -> typing.AnyStr:
-    return n2t_regex.sub("", raw_id)
 
 class SmithsonianItem(object):
     AUTHORITY_ID = "SMITHSONIAN"
@@ -41,7 +35,7 @@ class SmithsonianItem(object):
             resolve_elapsed=0,
         )
         if not isinstance(self.source_item, dict):
-            L.error("Item is not an object")
+            logging.error("Item is not an object")
             return _thing
         _thing.item_type = "sample"
         _thing.resolved_media_type = SmithsonianItem.TEXT_CSV
@@ -71,7 +65,7 @@ def load_thing(
     # For the purposes of the Things db, we want to use a normalized form of the identifier.  Note that there is one
     # other column in the Smithsonian dump that we'd need to transform to the normalized form if we wanted to use it,
     # that is occurrenceID.  Currently it is unused in our Transformer codebase.
-    normalized_id = _normalized_id(thing_dict["id"])
+    normalized_id = isb_lib.core.normalized_id(thing_dict["id"])
     try:
         t_created = datetime.datetime(
             year=int(thing_dict["year"]),

--- a/isb_lib/smithsonian_adapter.py
+++ b/isb_lib/smithsonian_adapter.py
@@ -3,6 +3,7 @@ import datetime
 
 import isamples_metadata.SmithsonianTransformer
 
+import isb_lib
 import isb_lib.core
 import logging
 
@@ -66,7 +67,7 @@ def load_thing(
     # For the purposes of the Things db, we want to use a normalized form of the identifier.  Note that there is one
     # other column in the Smithsonian dump that we'd need to transform to the normalized form if we wanted to use it,
     # that is occurrenceID.  Currently it is unused in our Transformer codebase.
-    normalized_id = isb_lib.core.normalized_id(thing_dict["id"])
+    normalized_id = isb_lib.normalized_id(thing_dict["id"])
     try:
         t_created = datetime.datetime(
             year=int(thing_dict["year"]),

--- a/isb_lib/smithsonian_adapter.py
+++ b/isb_lib/smithsonian_adapter.py
@@ -8,6 +8,7 @@ import logging
 
 from isb_lib.models.thing import Thing
 
+
 class SmithsonianItem(object):
     AUTHORITY_ID = "SMITHSONIAN"
     TEXT_CSV = "text/csv"

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -11,6 +11,7 @@ from fastapi.params import Query, Depends
 from sqlmodel import Session
 
 import isb_web
+import isamples_metadata.GEOMETransformer
 from isb_web import sqlmodel_database
 from isb_web import schemas
 from isb_web import crud
@@ -18,7 +19,6 @@ from isb_web import config
 from isb_web import isb_format
 from isb_web import isb_solr_query
 from isamples_metadata.SESARTransformer import SESARTransformer
-from isamples_metadata.GEOMETransformer import GEOMETransformer
 from isamples_metadata.OpenContextTransformer import OpenContextTransformer
 from isamples_metadata.SmithsonianTransformer import SmithsonianTransformer
 
@@ -232,7 +232,7 @@ async def get_thing(
         if authority_id == "SESAR":
             content = SESARTransformer(item.resolved_content).transform()
         elif authority_id == "GEOME":
-            content = GEOMETransformer(item.resolved_content).transform()
+            content = isamples_metadata.GEOMETransformer.geome_transformer_for_identifier(identifier, item.resolved_content).transform()
         elif authority_id == "OPENCONTEXT":
             content = OpenContextTransformer(item.resolved_content).transform()
         elif authority_id == "SMITHSONIAN":

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -7,7 +7,7 @@ from sqlalchemy import Index
 from sqlalchemy.exc import ProgrammingError
 from sqlmodel import SQLModel, create_engine, Session, select
 
-import isb_lib.core
+import isb_lib
 from isb_lib.models.thing import Thing, ThingIdentifier
 from isb_web.schemas import ThingPage
 
@@ -211,7 +211,7 @@ def _insert_geome_identifiers(session: Session, thing: Thing):
 def _insert_open_context_identifiers(session: Session, thing: Thing):
     citation_uri = thing.resolved_content["citation uri"]
     if citation_uri is not None and type(citation_uri) is str:
-        open_context_uri = isb_lib.core.normalized_id(citation_uri)
+        open_context_uri = isb_lib.normalized_id(citation_uri)
         open_context_identifier = ThingIdentifier(
             guid=open_context_uri, thing_id=thing.primary_key
         )

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 from sqlalchemy import Index
 from sqlalchemy.exc import ProgrammingError
 from sqlmodel import SQLModel, create_engine, Session, select
-from isb_lib.models.thing import Thing, Identifier
+from isb_lib.models.thing import Thing, ThingIdentifier
 from isb_web.schemas import ThingPage
 
 
@@ -57,7 +57,7 @@ class SQLModelDAO:
         self._create_index(resolved_status_authority_id_idx)
 
         guid_thing_id_idx = Index(
-            "guid_thing_id_idx", Identifier.guid, Identifier.thing_id
+            "guid_thing_id_idx", ThingIdentifier.guid, ThingIdentifier.thing_id
         )
         self._create_index(guid_thing_id_idx)
 
@@ -107,7 +107,7 @@ def get_thing_with_id(session: Session, identifier: str) -> Optional[Thing]:
     result = session.exec(statement).first()
     if result is None:
         # Fall back to querying the Identifiers table
-        join_statement = select(Thing, Identifier).where(Identifier.guid == identifier and Identifier.thing_id == Thing.primary_key)
+        join_statement = select(Thing, ThingIdentifier).where(ThingIdentifier.guid == identifier and ThingIdentifier.thing_id == Thing.primary_key)
         result = session.exec(join_statement).first()
         if result is not None:
             result = result[0]

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -110,7 +110,11 @@ def get_thing_with_id(session: Session, identifier: str) -> Optional[Thing]:
     result = session.exec(statement).first()
     if result is None:
         # Fall back to querying the Identifiers table
-        join_statement = select(Thing).join(ThingIdentifier).where(ThingIdentifier.guid == identifier)
+        join_statement = (
+            select(Thing)
+            .join(ThingIdentifier)
+            .where(ThingIdentifier.guid == identifier)
+        )
         result = session.exec(join_statement).first()
     return result
 
@@ -198,7 +202,9 @@ def _insert_geome_identifiers(session: Session, thing: Thing):
     if children is not None:
         for child in children:
             child_ark = child["bcid"]
-            child_identifier = ThingIdentifier(guid=child_ark, thing_id=thing.primary_key)
+            child_identifier = ThingIdentifier(
+                guid=child_ark, thing_id=thing.primary_key
+            )
             session.add(child_identifier)
 
 
@@ -206,7 +212,9 @@ def _insert_open_context_identifiers(session: Session, thing: Thing):
     citation_uri = thing.resolved_content["citation uri"]
     if citation_uri is not None and type(citation_uri) is str:
         open_context_uri = isb_lib.core.normalized_id(citation_uri)
-        open_context_identifier = ThingIdentifier(guid=open_context_uri, thing_id=thing.primary_key)
+        open_context_identifier = ThingIdentifier(
+            guid=open_context_uri, thing_id=thing.primary_key
+        )
         session.add(open_context_identifier)
 
 
@@ -228,7 +236,9 @@ def delete_identifiers(session: Session, thing: Thing) -> bool:
         # No pk, hasn't been saved
         return False
     else:
-        identifier_select = select(ThingIdentifier).where(ThingIdentifier.thing_id == thing.primary_key)
+        identifier_select = select(ThingIdentifier).where(
+            ThingIdentifier.thing_id == thing.primary_key
+        )
         thing_identifiers = session.exec(identifier_select).all()
         for identifier in thing_identifiers:
             session.delete(identifier)

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -107,10 +107,8 @@ def get_thing_with_id(session: Session, identifier: str) -> Optional[Thing]:
     result = session.exec(statement).first()
     if result is None:
         # Fall back to querying the Identifiers table
-        join_statement = select(Thing, ThingIdentifier).where(ThingIdentifier.guid == identifier and ThingIdentifier.thing_id == Thing.primary_key)
+        join_statement = select(Thing).join(ThingIdentifier).where(ThingIdentifier.guid == identifier)
         result = session.exec(join_statement).first()
-        if result is not None:
-            result = result[0]
     return result
 
 

--- a/scripts/geome_things.py
+++ b/scripts/geome_things.py
@@ -15,7 +15,7 @@ import click
 import click_config_file
 from isb_lib.models.thing import Thing
 from isb_web import sqlmodel_database
-from isb_web.sqlmodel_database import SQLModelDAO, get_thing_with_id
+from isb_web.sqlmodel_database import SQLModelDAO, get_thing_with_id, save_thing
 
 CONCURRENT_DOWNLOADS = 10
 BACKLOG_SIZE = 40
@@ -93,8 +93,7 @@ async def _loadGEOMEEntries(session, max_count, start_from=None):
                     futures.remove(fut)
                     if not _thing is None:
                         try:
-                            session.add(_thing)
-                            session.commit()
+                            save_thing(_thing)
                         except sqlalchemy.exc.IntegrityError as e:
                             session.rollback()
                             logging.error("Item already exists: %s", _id[0])

--- a/scripts/geome_things.py
+++ b/scripts/geome_things.py
@@ -93,7 +93,7 @@ async def _loadGEOMEEntries(session, max_count, start_from=None):
                     futures.remove(fut)
                     if not _thing is None:
                         try:
-                            save_thing(_thing)
+                            save_thing(session, _thing)
                         except sqlalchemy.exc.IntegrityError as e:
                             session.rollback()
                             logging.error("Item already exists: %s", _id[0])

--- a/scripts/opencontext_things.py
+++ b/scripts/opencontext_things.py
@@ -47,7 +47,7 @@ async def _load_open_context_entries(session, max_count, start_from):
             isb_lib.opencontext_adapter.update_thing(
                 existing_thing, record, datetime.datetime.now(), records.last_url_str()
             )
-            session.commit()
+            save_thing(session, existing_thing)
             logging.info("Just saved existing thing")
         else:
             logging.debug("Don't have %s", id)

--- a/scripts/opencontext_things.py
+++ b/scripts/opencontext_things.py
@@ -12,7 +12,7 @@ import sqlalchemy.orm
 import sqlalchemy.exc
 
 from isb_web import sqlmodel_database
-from isb_web.sqlmodel_database import SQLModelDAO
+from isb_web.sqlmodel_database import SQLModelDAO, save_thing
 
 BACKLOG_SIZE = 40
 
@@ -55,11 +55,7 @@ async def _load_open_context_entries(session, max_count, start_from):
                 record, datetime.datetime.now(), records.last_url_str()
             )
             try:
-                logging.debug("Going to add thing to session")
-                session.add(thing)
-                logging.debug("Added thing to session")
-                session.commit()
-                logging.debug("committed session")
+                save_thing(session, thing)
             except sqlalchemy.exc.IntegrityError as e:
                 session.rollback()
                 logging.error("Item already exists: %s", record)

--- a/scripts/opencontext_things.py
+++ b/scripts/opencontext_things.py
@@ -91,9 +91,7 @@ def load_open_context_entries(session, max_count, start_from=None):
 @click.option(
     "-d", "--db_url", default=None, help="SQLAlchemy database URL for storage"
 )
-@click.option(
-    "-s", "--solr_url", default=None, help="Solr index URL"
-)
+@click.option("-s", "--solr_url", default=None, help="Solr index URL")
 @click.option(
     "-v",
     "--verbosity",
@@ -147,10 +145,13 @@ def populate_isb_core_solr(ctx):
         db_batch_size=1000,
         solr_batch_size=1000,
         solr_url=solr_url,
-        min_time_created=max_solr_updated_date
+        min_time_created=max_solr_updated_date,
     )
-    allkeys = solr_importer.run_solr_import(isb_lib.opencontext_adapter.reparse_as_core_record)
+    allkeys = solr_importer.run_solr_import(
+        isb_lib.opencontext_adapter.reparse_as_core_record
+    )
     L.info(f"Total keys= {len(allkeys)}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/sesar_things.py
+++ b/scripts/sesar_things.py
@@ -15,7 +15,7 @@ import click_config_file
 
 from isb_lib.models.thing import Thing
 from isb_web import sqlmodel_database
-from isb_web.sqlmodel_database import SQLModelDAO
+from isb_web.sqlmodel_database import SQLModelDAO, save_thing
 
 CONCURRENT_DOWNLOADS = 10
 BACKLOG_SIZE = 40
@@ -86,8 +86,7 @@ async def _loadSesarEntries(session, max_count, start_from=None):
                     futures.remove(fut)
                     if not _thing is None:
                         try:
-                            session.add(_thing)
-                            session.commit()
+                            save_thing(session, _thing)
                         except sqlalchemy.exc.IntegrityError as e:
                             session.rollback()
                             logging.error("Item already exists: %s", _id[0])

--- a/scripts/smithsonian_things.py
+++ b/scripts/smithsonian_things.py
@@ -7,7 +7,7 @@ import isb_lib.smithsonian_adapter
 import logging
 import sqlalchemy
 import datetime
-from isb_web.sqlmodel_database import get_thing_with_id, SQLModelDAO
+from isb_web.sqlmodel_database import get_thing_with_id, SQLModelDAO, save_thing
 
 
 def _save_record_to_db(session, file_path, record):
@@ -22,11 +22,7 @@ def _save_record_to_db(session, file_path, record):
             record, datetime.datetime.now(), file_path
         )
         try:
-            logging.debug("Going to add thing to session")
-            session.add(thing)
-            logging.debug("Added thing to session")
-            session.commit()
-            logging.debug("committed session")
+            save_thing(session, thing)
         except sqlalchemy.exc.IntegrityError as e:
             session.rollback()
             logging.error("Item already exists: %s", record)

--- a/scripts/smithsonian_things.py
+++ b/scripts/smithsonian_things.py
@@ -57,9 +57,7 @@ def load_smithsonian_entries(session, max_count, file_path, start_from=None):
 @click.option(
     "-d", "--db_url", default=None, help="SQLAlchemy database URL for storage"
 )
-@click.option(
-    "-s", "--solr_url", default=None, help="Solr index URL"
-)
+@click.option("-s", "--solr_url", default=None, help="Solr index URL")
 @click.option(
     "-v",
     "--verbosity",

--- a/scripts/update_identifiers_for_existing_things.py
+++ b/scripts/update_identifiers_for_existing_things.py
@@ -45,7 +45,7 @@ def insert_geome_identifiers(session, thing):
 def insert_open_context_identifiers(session, thing):
     citation_uri = thing.resolved_content["citation uri"]
     if citation_uri is not None and type(citation_uri) is str:
-        open_context_uri = isb_lib.core.normalized_id(citation_uri)
+        open_context_uri = isb_lib.normalized_id(citation_uri)
         open_context_identifier = ThingIdentifier(
             guid=open_context_uri, thing_id=thing.primary_key
         )

--- a/scripts/update_identifiers_for_existing_things.py
+++ b/scripts/update_identifiers_for_existing_things.py
@@ -1,0 +1,91 @@
+from time import sleep
+
+import click
+import click_config_file
+from sqlalchemy import delete
+from sqlmodel import select
+
+import isb_lib
+import isb_lib.core
+from isb_lib.models.thing import Thing, ThingIdentifier
+from isb_web.sqlmodel_database import SQLModelDAO
+
+arks_to_bp = ["ark:/21547/Duf242514eacdfe6ca78a925008f7c003082", "ark:/21547/DsN2abdc7db9aa0e9d1b24061c87005b561e"]
+opencontext_ids = ["http://opencontext.org/subjects/5d917e24-52ec-4c10-8a51-a1586c1c451f", "http://opencontext.org/subjects/DD2E7987-6313-4FAD-C4BE-A8980D181854"]
+
+def insert_geome_identifiers(session, thing):
+    # For now, we will fail all requests for parent IDs, because events appear in multiple samples
+    # and would violate referential integrity if we made pointers to children from the event ID
+    # parent = thing.resolved_content.get("parent")
+    # if parent is not None:
+    #     event_ark = parent["bcid"]
+    #     if event_ark in arks_to_bp:
+    #         print()
+    #     event_identifier = ThingIdentifier(guid=event_ark, thing_id=thing.primary_key)
+    #     session.add(event_identifier)
+    children = thing.resolved_content.get("children")
+    if children is not None:
+        for child in children:
+            child_ark = child["bcid"]
+            if child_ark in arks_to_bp:
+                print()
+            child_identifier = ThingIdentifier(guid=child_ark, thing_id=thing.primary_key)
+            session.add(child_identifier)
+
+
+def insert_open_context_identifiers(session, thing):
+    open_context_uri = thing.resolved_content["uri"]
+    open_context_identifier = ThingIdentifier(guid=open_context_uri, thing_id=thing.primary_key)
+    if open_context_uri in opencontext_ids:
+        print()
+    session.add(open_context_identifier)
+
+
+def insert_standard_identifier(session, thing):
+    if thing.id in arks_to_bp:
+        print()
+    thing_identifier = ThingIdentifier(guid=thing.id, thing_id=thing.primary_key)
+    session.add(thing_identifier)
+
+
+@click.command()
+@click.option(
+    "-d", "--db_url", default=None, help="SQLAlchemy database URL for storage"
+)
+@click.option(
+    "-v",
+    "--verbosity",
+    default="DEBUG",
+    help="Specify logging level",
+    show_default=True,
+)
+@click.option(
+    "-H", "--heart_rate", is_flag=True, help="Show heartrate diagnositcs on 9999"
+)
+@click_config_file.configuration_option(config_file_name="isb.cfg")
+@click.pass_context
+def main(ctx, db_url, verbosity, heart_rate):
+    isb_lib.core.things_main(ctx, db_url, None, verbosity, heart_rate)
+    session = SQLModelDAO((ctx.obj["db_url"])).get_session()
+    # start off cleaning out any existing records
+    rows_deleted = session.query(ThingIdentifier).delete()
+    print("Deleted %d rows before recreating entries", rows_deleted)
+    session.commit()
+    sleep(10)
+    index = 0
+    page_size = 1000
+    max_index = 5000
+    while index < max_index:
+        statement = select(Thing).order_by(Thing.primary_key.asc()).slice(index, index + page_size)
+        for thing in session.exec(statement):
+            if thing.authority_id == "GEOME":
+                insert_geome_identifiers(session, thing)
+            elif thing.authority_id == "OPENCONTEXT":
+                insert_open_context_identifiers(session, thing)
+            insert_standard_identifier(session, thing)
+        session.commit()
+        index += page_size
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_identifiers_for_existing_things.py
+++ b/scripts/update_identifiers_for_existing_things.py
@@ -9,8 +9,16 @@ import isb_lib.core
 from isb_lib.models.thing import Thing, ThingIdentifier
 from isb_web.sqlmodel_database import SQLModelDAO
 
-arks_to_bp = ["ark:/21547/Duf242514eacdfe6ca78a925008f7c003082", "ark:/21547/DsN2abdc7db9aa0e9d1b24061c87005b561e", "ark:/21547/Dsw2T1um44.1"]
-opencontext_ids = ["http://opencontext.org/subjects/5d917e24-52ec-4c10-8a51-a1586c1c451f", "http://opencontext.org/subjects/DD2E7987-6313-4FAD-C4BE-A8980D181854"]
+arks_to_bp = [
+    "ark:/21547/Duf242514eacdfe6ca78a925008f7c003082",
+    "ark:/21547/DsN2abdc7db9aa0e9d1b24061c87005b561e",
+    "ark:/21547/Dsw2T1um44.1",
+]
+opencontext_ids = [
+    "http://opencontext.org/subjects/5d917e24-52ec-4c10-8a51-a1586c1c451f",
+    "http://opencontext.org/subjects/DD2E7987-6313-4FAD-C4BE-A8980D181854",
+]
+
 
 def insert_geome_identifiers(session, thing):
     # For now, we will fail all requests for parent IDs, because events appear in multiple samples
@@ -28,7 +36,9 @@ def insert_geome_identifiers(session, thing):
             child_ark = child["bcid"]
             if child_ark in arks_to_bp:
                 print()
-            child_identifier = ThingIdentifier(guid=child_ark, thing_id=thing.primary_key)
+            child_identifier = ThingIdentifier(
+                guid=child_ark, thing_id=thing.primary_key
+            )
             session.add(child_identifier)
 
 
@@ -36,7 +46,9 @@ def insert_open_context_identifiers(session, thing):
     citation_uri = thing.resolved_content["citation uri"]
     if citation_uri is not None and type(citation_uri) is str:
         open_context_uri = isb_lib.core.normalized_id(citation_uri)
-        open_context_identifier = ThingIdentifier(guid=open_context_uri, thing_id=thing.primary_key)
+        open_context_identifier = ThingIdentifier(
+            guid=open_context_uri, thing_id=thing.primary_key
+        )
         if open_context_uri in arks_to_bp:
             print()
         session.add(open_context_identifier)

--- a/scripts/update_identifiers_for_existing_things.py
+++ b/scripts/update_identifiers_for_existing_things.py
@@ -2,7 +2,6 @@ from time import sleep
 
 import click
 import click_config_file
-from sqlalchemy import delete
 from sqlmodel import select
 
 import isb_lib
@@ -34,11 +33,13 @@ def insert_geome_identifiers(session, thing):
 
 
 def insert_open_context_identifiers(session, thing):
-    open_context_uri = thing.resolved_content["uri"]
-    open_context_identifier = ThingIdentifier(guid=open_context_uri, thing_id=thing.primary_key)
-    if open_context_uri in opencontext_ids:
-        print()
-    session.add(open_context_identifier)
+    citation_uri = thing.resolved_content["citation uri"]
+    if citation_uri is not None:
+        open_context_uri = isb_lib.core.normalized_id(citation_uri)
+        open_context_identifier = ThingIdentifier(guid=open_context_uri, thing_id=thing.primary_key)
+        if open_context_uri in opencontext_ids:
+            print()
+        session.add(open_context_identifier)
 
 
 def insert_standard_identifier(session, thing):
@@ -73,8 +74,8 @@ def main(ctx, db_url, verbosity, heart_rate):
     session.commit()
     sleep(10)
     index = 0
-    page_size = 1000
-    max_index = 5000
+    page_size = 10000
+    max_index = 6000000
     while index < max_index:
         statement = select(Thing).order_by(Thing.primary_key.asc()).slice(index, index + page_size)
         for thing in session.exec(statement):

--- a/tests/test_smithsonian.py
+++ b/tests/test_smithsonian.py
@@ -1,11 +1,12 @@
+import isb_lib
 import isb_lib.core
 
 
 def test_normalized_identifier():
     raw_id = "https://n2t.net/foobarbaz"
-    normalized_id = isb_lib.core.normalized_id(raw_id)
+    normalized_id = isb_lib.normalized_id(raw_id)
     assert "foobarbaz" == normalized_id
 
     raw_id = "http://n2t.net/joeyjohnny"
-    normalized_id = isb_lib.core.normalized_id(raw_id)
+    normalized_id = isb_lib.normalized_id(raw_id)
     assert "joeyjohnny" == normalized_id

--- a/tests/test_smithsonian.py
+++ b/tests/test_smithsonian.py
@@ -1,11 +1,11 @@
-from isb_lib import smithsonian_adapter
+import isb_lib.core
 
 
 def test_normalized_identifier():
     raw_id = "https://n2t.net/foobarbaz"
-    normalized_id = smithsonian_adapter._normalized_id(raw_id)
+    normalized_id = isb_lib.core.normalized_id(raw_id)
     assert "foobarbaz" == normalized_id
 
     raw_id = "http://n2t.net/joeyjohnny"
-    normalized_id = smithsonian_adapter._normalized_id(raw_id)
+    normalized_id = isb_lib.core.normalized_id(raw_id)
     assert "joeyjohnny" == normalized_id

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -5,7 +5,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from isb_lib.core import ThingRecordIterator
-from isb_lib.models.thing import Thing, Identifier
+from isb_lib.models.thing import Thing, ThingIdentifier
 from isb_web.sqlmodel_database import get_thing_with_id, read_things_summary, last_time_thing_created, \
     paged_things_with_ids
 
@@ -117,7 +117,7 @@ def test_thing_with_identifier(session: Session):
     # Right now, query by that id shouldn't find anything
     thing_with_identifier = get_thing_with_id(session, test_id)
     assert thing_with_identifier is None
-    new_identifier = Identifier(guid=test_id, thing_id=new_thing.primary_key)
+    new_identifier = ThingIdentifier(guid=test_id, thing_id=new_thing.primary_key)
     session.add(new_identifier)
     session.commit()
     # Just added ID, should find it now

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -1,13 +1,14 @@
 import datetime
+import typing
 
 import pytest
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 from isb_lib.core import ThingRecordIterator
 from isb_lib.models.thing import Thing, ThingIdentifier
 from isb_web.sqlmodel_database import get_thing_with_id, read_things_summary, last_time_thing_created, \
-    paged_things_with_ids
+    paged_things_with_ids, insert_identifiers, save_thing
 
 
 @pytest.fixture(name="session")
@@ -127,3 +128,64 @@ def test_thing_with_identifier(session: Session):
     thing_with_identifier = get_thing_with_id(session, test_id)
     assert thing_with_identifier is not None
     assert thing_id == thing_with_identifier.id
+
+
+def _fetch_thing_identifiers(session: Session) -> typing.List[ThingIdentifier]:
+    return session.exec(select(ThingIdentifier)).all()
+
+
+def _test_insert_identifiers(session: Session, thing: Thing) -> typing.List[ThingIdentifier]:
+    session.add(thing)
+    session.commit()
+    insert_identifiers(session, thing)
+    session.commit()
+    # should have two ids for specified thing
+    ids = _fetch_thing_identifiers(session)
+    return ids
+
+
+def test_insert_identifiers_geome(session: Session):
+    thing_id = "123456"
+    child_id = "1234567890"
+    geome_thing = Thing(id=thing_id, authority_id="GEOME", resolved_url="http://foo.bar", resolved_status=200, resolved_content = {"children": [{"bcid": child_id}]})
+    identifiers = _test_insert_identifiers(session, geome_thing)
+    assert 2 == len(identifiers)
+
+
+def test_insert_identifiers_opencontext(session: Session):
+    thing_id = "7890"
+    citation_uri = "12345"
+    opencontext_thing = Thing(id=thing_id, authority_id="OPENCONTEXT", resolved_url="http://foo.bar", resolved_status=200,
+                        resolved_content={"citation uri": citation_uri})
+    identifiers = _test_insert_identifiers(session, opencontext_thing)
+    assert 2 == len(identifiers)
+
+
+def test_insert_identifiers_sesar(session: Session):
+    thing_id = "7890"
+    sesar_thing = Thing(id=thing_id, authority_id="SESAR", resolved_url="http://foo.bar", resolved_status=200,
+                        resolved_content={})
+    identifiers = _test_insert_identifiers(session, sesar_thing)
+    assert 1 == len(identifiers)
+
+
+def test_save_thing(session: Session) -> Thing:
+    sesar_thing = Thing(id="12345", authority_id="SESAR", resolved_url="http://foo.bar", resolved_status=200,
+                        resolved_content={})
+    save_thing(session, sesar_thing)
+    # we should have a ThingIdentifier now
+    ids = _fetch_thing_identifiers(session)
+    assert 1 == len(ids)
+    return sesar_thing
+
+
+def test_save_existing_thing(session: Session):
+    existing_thing = test_save_thing(session)
+    # touch the timestamp to update the Thing
+    existing_thing.tstamp = datetime.datetime.now()
+    save_thing(session, existing_thing)
+    ids = _fetch_thing_identifiers(session)
+    # should still have 1 id since we whacked the old ones during the save
+    assert 1 == len(ids)
+
+

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -7,8 +7,14 @@ from sqlmodel.pool import StaticPool
 
 from isb_lib.core import ThingRecordIterator
 from isb_lib.models.thing import Thing, ThingIdentifier
-from isb_web.sqlmodel_database import get_thing_with_id, read_things_summary, last_time_thing_created, \
-    paged_things_with_ids, insert_identifiers, save_thing
+from isb_web.sqlmodel_database import (
+    get_thing_with_id,
+    read_things_summary,
+    last_time_thing_created,
+    paged_things_with_ids,
+    insert_identifiers,
+    save_thing,
+)
 
 
 @pytest.fixture(name="session")
@@ -30,7 +36,13 @@ def test_get_thing_with_id_no_things(session: Session):
 
 def test_get_thing_with_id_thing(session: Session):
     id = "123456"
-    new_thing = Thing(id=id, authority_id="test", resolved_url="http://foo.bar", resolved_status=200, resolved_content = { "foo": "bar" })
+    new_thing = Thing(
+        id=id,
+        authority_id="test",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={"foo": "bar"},
+    )
     session.add(new_thing)
     session.commit()
     shouldnt_be_none = get_thing_with_id(session, id)
@@ -47,7 +59,13 @@ def test_read_things_no_things(session: Session):
 
 
 def test_read_things_with_things(session: Session):
-    new_thing = Thing(id="123456", authority_id="test", resolved_url="http://foo.bar", resolved_status=200, resolved_content = { "foo": "bar" })
+    new_thing = Thing(
+        id="123456",
+        authority_id="test",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={"foo": "bar"},
+    )
     session.add(new_thing)
     session.commit()
     count, pages, data = read_things_summary(session, 0, 0)
@@ -60,18 +78,34 @@ def test_last_time_thing_created(session: Session):
     test_authority = "test"
     created = last_time_thing_created(session, test_authority)
     assert created is None
-    new_thing = Thing(id="123456", authority_id=test_authority, resolved_url="http://foo.bar", resolved_status=200,
-                      resolved_content={"foo": "bar"}, tcreated=datetime.datetime.now())
+    new_thing = Thing(
+        id="123456",
+        authority_id=test_authority,
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={"foo": "bar"},
+        tcreated=datetime.datetime.now(),
+    )
     session.add(new_thing)
     session.commit()
     new_created = last_time_thing_created(session, test_authority)
     assert new_created is not None
 
 
-def _add_some_things(session: Session, num_things: int, authority_id: str, tcreated: datetime.datetime = None):
+def _add_some_things(
+    session: Session,
+    num_things: int,
+    authority_id: str,
+    tcreated: datetime.datetime = None,
+):
     for i in range(num_things):
-        new_thing = Thing(id=str(i), authority_id=authority_id, resolved_url="http://foo.bar", resolved_status=200,
-                          resolved_content={"foo": "bar"})
+        new_thing = Thing(
+            id=str(i),
+            authority_id=authority_id,
+            resolved_url="http://foo.bar",
+            resolved_status=200,
+            resolved_content={"foo": "bar"},
+        )
         if tcreated is not None:
             new_thing.tcreated = tcreated
         session.add(new_thing)
@@ -112,7 +146,13 @@ def test_thing_iterator(session: Session):
 
 def test_thing_with_identifier(session: Session):
     thing_id = "123456"
-    new_thing = Thing(id=thing_id, authority_id="test", resolved_url="http://foo.bar", resolved_status=200, resolved_content = {"foo": "bar"})
+    new_thing = Thing(
+        id=thing_id,
+        authority_id="test",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={"foo": "bar"},
+    )
     session.add(new_thing)
     session.commit()
     test_id = "ark:/123456"
@@ -134,7 +174,9 @@ def _fetch_thing_identifiers(session: Session) -> typing.List[ThingIdentifier]:
     return session.exec(select(ThingIdentifier)).all()
 
 
-def _test_insert_identifiers(session: Session, thing: Thing) -> typing.List[ThingIdentifier]:
+def _test_insert_identifiers(
+    session: Session, thing: Thing
+) -> typing.List[ThingIdentifier]:
     session.add(thing)
     session.commit()
     insert_identifiers(session, thing)
@@ -147,7 +189,13 @@ def _test_insert_identifiers(session: Session, thing: Thing) -> typing.List[Thin
 def test_insert_identifiers_geome(session: Session):
     thing_id = "123456"
     child_id = "1234567890"
-    geome_thing = Thing(id=thing_id, authority_id="GEOME", resolved_url="http://foo.bar", resolved_status=200, resolved_content = {"children": [{"bcid": child_id}]})
+    geome_thing = Thing(
+        id=thing_id,
+        authority_id="GEOME",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={"children": [{"bcid": child_id}]},
+    )
     identifiers = _test_insert_identifiers(session, geome_thing)
     assert 2 == len(identifiers)
 
@@ -155,23 +203,38 @@ def test_insert_identifiers_geome(session: Session):
 def test_insert_identifiers_opencontext(session: Session):
     thing_id = "7890"
     citation_uri = "12345"
-    opencontext_thing = Thing(id=thing_id, authority_id="OPENCONTEXT", resolved_url="http://foo.bar", resolved_status=200,
-                        resolved_content={"citation uri": citation_uri})
+    opencontext_thing = Thing(
+        id=thing_id,
+        authority_id="OPENCONTEXT",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={"citation uri": citation_uri},
+    )
     identifiers = _test_insert_identifiers(session, opencontext_thing)
     assert 2 == len(identifiers)
 
 
 def test_insert_identifiers_sesar(session: Session):
     thing_id = "7890"
-    sesar_thing = Thing(id=thing_id, authority_id="SESAR", resolved_url="http://foo.bar", resolved_status=200,
-                        resolved_content={})
+    sesar_thing = Thing(
+        id=thing_id,
+        authority_id="SESAR",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={},
+    )
     identifiers = _test_insert_identifiers(session, sesar_thing)
     assert 1 == len(identifiers)
 
 
 def test_save_thing(session: Session) -> Thing:
-    sesar_thing = Thing(id="12345", authority_id="SESAR", resolved_url="http://foo.bar", resolved_status=200,
-                        resolved_content={})
+    sesar_thing = Thing(
+        id="12345",
+        authority_id="SESAR",
+        resolved_url="http://foo.bar",
+        resolved_status=200,
+        resolved_content={},
+    )
     save_thing(session, sesar_thing)
     # we should have a ThingIdentifier now
     ids = _fetch_thing_identifiers(session)
@@ -187,5 +250,3 @@ def test_save_existing_thing(session: Session):
     ids = _fetch_thing_identifiers(session)
     # should still have 1 id since we whacked the old ones during the save
     assert 1 == len(ids)
-
-

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -110,7 +110,8 @@ def test_thing_iterator(session: Session):
 
 
 def test_thing_with_identifier(session: Session):
-    new_thing = Thing(id="123456", authority_id="test", resolved_url="http://foo.bar", resolved_status=200, resolved_content = { "foo": "bar" })
+    thing_id = "123456"
+    new_thing = Thing(id=thing_id, authority_id="test", resolved_url="http://foo.bar", resolved_status=200, resolved_content = {"foo": "bar"})
     session.add(new_thing)
     session.commit()
     test_id = "ark:/123456"
@@ -119,7 +120,10 @@ def test_thing_with_identifier(session: Session):
     assert thing_with_identifier is None
     new_identifier = ThingIdentifier(guid=test_id, thing_id=new_thing.primary_key)
     session.add(new_identifier)
+    new_identifier2 = ThingIdentifier(guid="http://not.real", thing_id="67890")
+    session.add(new_identifier2)
     session.commit()
     # Just added ID, should find it now
     thing_with_identifier = get_thing_with_id(session, test_id)
     assert thing_with_identifier is not None
+    assert thing_id == thing_with_identifier.id


### PR DESCRIPTION
Wire in support for alternate identifiers so we may look up GEOME child records and OpenContext records by their publication identifiers.  Still need to test it live as part of the import process.