### PR TITLE
Create an option to rebuild the full solr index

### DIFF
--- a/scripts/opencontext_things.py
+++ b/scripts/opencontext_things.py
@@ -129,15 +129,21 @@ def load_records(ctx, max_records):
 
 
 @main.command("populate_isb_core_solr")
+@click.option(
+    "-I", "--ignore_last_modified", is_flag=True, help="Whether to ignore the last modified date and do a full rebuild"
+)
 @click.pass_context
-def populate_isb_core_solr(ctx):
+def populate_isb_core_solr(ctx, ignore_last_modified: bool):
     L = get_logger()
     db_url = ctx.obj["db_url"]
     solr_url = ctx.obj["solr_url"]
-    max_solr_updated_date = isb_lib.core.solr_max_source_updated_time(
-        url=solr_url,
-        authority_id=isb_lib.opencontext_adapter.OpenContextItem.AUTHORITY_ID,
-    )
+    if ignore_last_modified:
+        max_solr_updated_date = None
+    else:
+        max_solr_updated_date = isb_lib.core.solr_max_source_updated_time(
+            url=solr_url,
+            authority_id=isb_lib.opencontext_adapter.OpenContextItem.AUTHORITY_ID,
+        )
     L.info(f"Going to index Things with tcreated > {max_solr_updated_date}")
     solr_importer = isb_lib.core.CoreSolrImporter(
         db_url=db_url,


### PR DESCRIPTION
Needed to fully rebuild OpenContext with new metadata mapping, didn't have a way to do that.