### PR TITLE
Need to wipe out Solr copy fields before we run a save

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -314,13 +314,20 @@ def solrAddRecords(rsession, records, url):
 
     """
 
-    # Need to strip previous generated fields to avoid solr inconsistency errors
+    # Need to strip previously generated fields to avoid solr inconsistency errors
     for record in records:
         record.pop("_version_", None)
         record.pop("producedBy_samplingSite_location_bb__minY", None)
         record.pop("producedBy_samplingSite_location_bb__minX", None)
         record.pop("producedBy_samplingSite_location_bb__maxY", None)
         record.pop("producedBy_samplingSite_location_bb__maxX", None)
+
+        # If we don't nuke all the copy fields, they'll end up copying over multiple times
+        record.pop("searchText", None)
+        record.pop("description_text", None)
+        record.pop("producedBy_description_text", None)
+        record.pop("producedBy_samplingSite_description_text", None)
+        record.pop("curation_description_text", None)
 
     L = getLogger()
     headers = {"Content-Type": "application/json"}

--- a/isb_lib/sitemaps/thing_sitemap.py
+++ b/isb_lib/sitemaps/thing_sitemap.py
@@ -94,7 +94,7 @@ class SitemapIndexIterator:
             self._last_timestamp_str = self._last_url_set_iterator.last_tstamp_str
             self._last_primary_key = self._last_url_set_iterator.last_identifier
         things = isb_solr_query.solr_records_for_sitemap(
-            self._rsession, self._authority, self._offset, self._num_things_per_file, "id,sourceUpdatedTime"
+            self._rsession, self._authority, self._offset, self._num_things_per_file
         )
         if len(things) == 0:
             raise StopIteration

--- a/scripts/solr_reindex_template.py
+++ b/scripts/solr_reindex_template.py
@@ -18,7 +18,7 @@ def mutate_record(record: typing.Dict) -> typing.Optional[typing.Dict]:
 @click.pass_context
 def main(ctx):
     """Starting point template for reindexing the iSB Core Solr schema.  Solr URL is contained in a file called
-    isb_web_config.env that should be located in the same directory as this file"""
+    isb_web_config.env that should be located in the same directory as this file."""
     solr_url = isb_web.config.Settings().solr_url
     isb_lib.core.things_main(ctx, None, solr_url, "INFO", False)
     total_records = 0

--- a/scripts/solr_reindex_template.py
+++ b/scripts/solr_reindex_template.py
@@ -1,0 +1,40 @@
+import typing
+
+import click
+import requests
+import logging
+
+import isb_lib.core
+import isb_web
+from isb_web.isb_solr_query import ISBCoreSolrRecordIterator
+
+
+def mutate_record(record: typing.Dict) -> typing.Optional[typing.Dict]:
+    # Do whatever work is required to mutate the record to update things…
+    return None
+
+
+@click.command()
+@click.pass_context
+def main(ctx):
+    solr_url = isb_web.config.Settings().solr_url
+    isb_lib.core.things_main(ctx, None, solr_url, "INFO", False)
+    total_records = 0
+    batch_size = 50000
+    current_mutated_batch = []
+    rsession = requests.session()
+    iterator = ISBCoreSolrRecordIterator(rsession, None, batch_size, 0, "id asc")
+    for record in iterator:
+        mutated_record = mutate_record(record)
+        if mutated_record is not None:
+            current_mutated_batch.append(mutated_record)
+        if len(current_mutated_batch) == batch_size:
+            isb_lib.core.solrAddRecords(rsession, current_mutated_batch, solr_url)
+            isb_lib.core.solrCommit(rsession, solr_url)
+            logging.info(f"Just saved {len(current_mutated_batch)} records")
+        total_records += 1
+    logging.info(f"Finished iterating, visited {total_records} records")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/solr_reindex_template.py
+++ b/scripts/solr_reindex_template.py
@@ -17,6 +17,8 @@ def mutate_record(record: typing.Dict) -> typing.Optional[typing.Dict]:
 @click.command()
 @click.pass_context
 def main(ctx):
+    """Starting point template for reindexing the iSB Core Solr schema.  Solr URL is contained in a file called
+    isb_web_config.env that should be located in the same directory as this file"""
     solr_url = isb_web.config.Settings().solr_url
     isb_lib.core.things_main(ctx, None, solr_url, "INFO", False)
     total_records = 0


### PR DESCRIPTION
We were seeing many duplicate copy fields in the solr results.  Wipe them out before saving.