### PR TITLE
Sqlite dump tool

### DIFF
--- a/isamples_metadata/Transformer.py
+++ b/isamples_metadata/Transformer.py
@@ -2,6 +2,9 @@ from abc import ABC, abstractmethod
 import typing
 
 
+NOT_PROVIDED = "Not Provided"
+
+
 class Transformer(ABC):
     """Abstract base class for various iSamples provider transformers"""
 

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -8,184 +8,248 @@ class ISBCoreRecord(SQLModel, table=True):
         default=None,
         nullable=False,
         primary_key=True,
-        description="The identifier in the original data, which should be a unique identifier (e.g. ark or igsn)"
+        description="The identifier in the original data, which should be a unique identifier (e.g. ark or igsn)",
     )
     isb_core_id: Optional[str] = Field(
         default=None,
         nullable=False,
-        description="The iSamples persistent identifier, which is how the sample is uniquely identified in iSamples"
+        description="The iSamples persistent identifier, which is how the sample is uniquely identified in iSamples",
     )
     isb_updated_time: Optional[str] = Field(
         default=None,
         nullable=False,
         description="The time the record was last updated in the iSamples index",
-        index=False
+        index=False,
     )
-    source_updated_time: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The time the record was last updated in the original data, if available",
-        index=False
-    ),
-    label: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A label for the record",
-        index=False
-    ),
-    search_text: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A collection of text suitable for use in a full-text search index, semicolon delimited",
-        index=False
-    ),
-    sample_description: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A textual description of the sample",
-        index=False
-    ),
-    context_categories: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The context categories from the iSamples controlled vocabulary, semicolon delimited",
-        index=False
-    ),
-    material_categories: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
-        index=False
-    ),
-    specimen_categories: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
-        index=False
-    ),
-    keywords: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="Keywords for searching, semicolon delimited",
-        index=False
-    ),
-    informal_classification: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="Informal scientific classification of the sample",
-        index=False
-    ),
-    produced_by_isb_core_id: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The iSB Core ID of the sample that produced this sample",
-        index=False
-    ),
-    produced_by_label: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A label for how the sample was produced",
-        index=False
-    ),
-    produced_by_description: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A text description for how the sample was produced",
-        index=False
-    ),
-    produced_by_feature_of_interest: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A string specifying whether the sample was produced by a feature of interest",
-        index=False
-    ),
-    produced_by_responsibility: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The name of the people or institution responsible for producing the sample, semicolon-delimited",
-        index=False
-    ),
-    produced_by_result_time: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="ISO8601 textual representation of the time the sample was collected",
-        index=False
-    ),
-    produced_by_sampling_site_description: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A textual description of the sampling site",
-        index=False
-    ),
-    produced_by_sampling_site_label: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A label for the sampling site",
-        index=False
-    ),
-    produced_by_sampling_site_elevation_in_meters: Optional[float] = Field(
-        default=0.0,
-        nullable=True,
-        description="The elevation in meters of the sampling site",
-        index=False
-    ),
-    produced_by_sampling_site_location_ll: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The latitude and longitude of the sampling site, in a comma-separated string",
-        index=False
-    ),
-    produced_by_sampling_site_place_name: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The place name of the sampling site",
-        index=False
-    ),
-    registrant: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The registrant of the sample",
-        index=False
-    ),
-    sampling_purpose: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="Why the sample was collected",
-        index=False
-    ),
-    curation_label: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A label for the sample used during curation",
-        index=False
-    ),
-    curation_description: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="A textual description of how the sample was curated",
-        index=False
-    ),
-    curation_access_constraints: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="Access constraints around the sample curation",
-        index=False
-    ),
-    curation_location: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="Where the sample is curated",
-        index=False
-    ),
-    curation_responsibility: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="The institution or people responsible for curation",
-        index=False
-    ),
-    related_resources_isb_core_id: Optional[str] = Field(
-        default=None,
-        nullable=True,
-        description="Identifiers for related resources, semicolon-delimited",
-        index=False
-    ),
+    source_updated_time: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The time the record was last updated in the original data, if available",
+            index=False,
+        ),
+    )
+    label: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A label for the record",
+            index=False,
+        ),
+    )
+    search_text: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A collection of text suitable for use in a full-text search index, semicolon delimited",
+            index=False,
+        ),
+    )
+    sample_description: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A textual description of the sample",
+            index=False,
+        ),
+    )
+    context_categories: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The context categories from the iSamples controlled vocabulary, semicolon delimited",
+            index=False,
+        ),
+    )
+    material_categories: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
+            index=False,
+        ),
+    )
+    specimen_categories: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
+            index=False,
+        ),
+    )
+    keywords: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Keywords for searching, semicolon delimited",
+            index=False,
+        ),
+    )
+    informal_classification: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Informal scientific classification of the sample",
+            index=False,
+        ),
+    )
+    produced_by_isb_core_id: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The iSB Core ID of the sample that produced this sample",
+            index=False,
+        ),
+    )
+    produced_by_label: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A label for how the sample was produced",
+            index=False,
+        ),
+    )
+    produced_by_description: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A text description for how the sample was produced",
+            index=False,
+        ),
+    )
+    produced_by_feature_of_interest: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A string specifying whether the sample was produced by a feature of interest",
+            index=False,
+        ),
+    )
+    produced_by_responsibility: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The name of the people or institution responsible for producing the sample, semicolon-delimited",
+            index=False,
+        ),
+    )
+    produced_by_result_time: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="ISO8601 textual representation of the time the sample was collected",
+            index=False,
+        ),
+    )
+    produced_by_sampling_site_description: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A textual description of the sampling site",
+            index=False,
+        ),
+    )
+    produced_by_sampling_site_label: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A label for the sampling site",
+            index=False,
+        ),
+    )
+    produced_by_sampling_site_elevation_in_meters: Optional[float] = (
+        Field(
+            default=0.0,
+            nullable=True,
+            description="The elevation in meters of the sampling site",
+            index=False,
+        ),
+    )
+    produced_by_sampling_site_location_ll: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The latitude and longitude of the sampling site, in a comma-separated string",
+            index=False,
+        ),
+    )
+    produced_by_sampling_site_place_name: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The place name of the sampling site",
+            index=False,
+        ),
+    )
+    registrant: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The registrant of the sample",
+            index=False,
+        ),
+    )
+    sampling_purpose: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Why the sample was collected",
+            index=False,
+        ),
+    )
+    curation_label: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A label for the sample used during curation",
+            index=False,
+        ),
+    )
+    curation_description: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="A textual description of how the sample was curated",
+            index=False,
+        ),
+    )
+    curation_access_constraints: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Access constraints around the sample curation",
+            index=False,
+        ),
+    )
+    curation_location: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Where the sample is curated",
+            index=False,
+        ),
+    )
+    curation_responsibility: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The institution or people responsible for curation",
+            index=False,
+        ),
+    )
+    related_resources_isb_core_id: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Identifiers for related resources, semicolon-delimited",
+            index=False,
+        ),
+    )
+    source: Optional[str] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="Source database where the original record is located",
+            index=False,
+        ),
+    )

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from sqlmodel import SQLModel, Field
+
+
+class ISBCoreRecord(SQLModel, table=True):
+    id: Optional[str] = Field(
+        default=None,
+        nullable=False,
+        primary_key=True,
+        description="Solr ID, which should be a unique identifier (e.g. ark or igsn)"
+    )

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -248,7 +248,7 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    related_resources_isb_core_id:  Optional[list] = Field(
+    related_resources_isb_core_id: Optional[list] = Field(
         # Use the raw SQLAlchemy column in order to get the proper JSON behavior
         sa_column=sqlalchemy.Column(
             sqlalchemy.JSON,

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -129,6 +129,12 @@ class ISBCoreRecord(SQLModel, table=True):
         description="The elevation in meters of the sampling site",
         index=False
     ),
+    produced_by_sampling_site_location_ll: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The latitude and longitude of the sampling site, in a comma-separated string",
+        index=False
+    ),
     produced_by_sampling_site_place_name: Optional[str] = Field(
         default=None,
         nullable=True,

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -171,3 +171,15 @@ class ISBCoreRecord(SQLModel, table=True):
         description="Where the sample is curated",
         index=False
     ),
+    curation_responsibility: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The institution or people responsible for curation",
+        index=False
+    ),
+    related_resources_isb_core_id: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Identifiers for related resources, semicolon-delimited",
+        index=False
+    ),

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -8,5 +8,166 @@ class ISBCoreRecord(SQLModel, table=True):
         default=None,
         nullable=False,
         primary_key=True,
-        description="Solr ID, which should be a unique identifier (e.g. ark or igsn)"
+        description="The identifier in the original data, which should be a unique identifier (e.g. ark or igsn)"
     )
+    isb_core_id: Optional[str] = Field(
+        default=None,
+        nullable=False,
+        description="The iSamples persistent identifier, which is how the sample is uniquely identified in iSamples"
+    )
+    isb_updated_time: Optional[str] = Field(
+        default=None,
+        nullable=False,
+        description="The time the record was last updated in the iSamples index",
+        index=False
+    )
+    source_updated_time: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The time the record was last updated in the original data, if available",
+        index=False
+    ),
+    label: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A label for the record",
+        index=False
+    ),
+    search_text: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A collection of text suitable for use in a full-text search index, semicolon delimited",
+        index=False
+    ),
+    sample_description: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A textual description of the sample",
+        index=False
+    ),
+    context_categories: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The context categories from the iSamples controlled vocabulary, semicolon delimited",
+        index=False
+    ),
+    material_categories: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
+        index=False
+    ),
+    specimen_categories: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
+        index=False
+    ),
+    keywords: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Keywords for searching, semicolon delimited",
+        index=False
+    ),
+    informal_classification: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Informal scientific classification of the sample",
+        index=False
+    ),
+    produced_by_isb_core_id: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The iSB Core ID of the sample that produced this sample",
+        index=False
+    ),
+    produced_by_label: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A label for how the sample was produced",
+        index=False
+    ),
+    produced_by_description: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A text description for how the sample was produced",
+        index=False
+    ),
+    produced_by_feature_of_interest: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A string specifying whether the sample was produced by a feature of interest",
+        index=False
+    ),
+    produced_by_responsibility: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The name of the people or institution responsible for producing the sample, semicolon-delimited",
+        index=False
+    ),
+    produced_by_result_time: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="ISO8601 textual representation of the time the sample was collected",
+        index=False
+    ),
+    produced_by_sampling_site_description: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A textual description of the sampling site",
+        index=False
+    ),
+    produced_by_sampling_site_label: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A label for the sampling site",
+        index=False
+    ),
+    produced_by_sampling_site_elevation_in_meters: Optional[float] = Field(
+        default=0.0,
+        nullable=True,
+        description="The elevation in meters of the sampling site",
+        index=False
+    ),
+    produced_by_sampling_site_place_name: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The place name of the sampling site",
+        index=False
+    ),
+    registrant: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="The registrant of the sample",
+        index=False
+    ),
+    sampling_purpose: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Why the sample was collected",
+        index=False
+    ),
+    curation_label: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A label for the sample used during curation",
+        index=False
+    ),
+    curation_description: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="A textual description of how the sample was curated",
+        index=False
+    ),
+    curation_access_constraints: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Access constraints around the sample curation",
+        index=False
+    ),
+    curation_location: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Where the sample is curated",
+        index=False
+    ),

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -1,5 +1,5 @@
 from typing import Optional
-
+import sqlalchemy
 from sqlmodel import SQLModel, Field
 
 
@@ -37,12 +37,14 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    search_text: Optional[str] = (
-        Field(
-            default=None,
+    # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+    search_text: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="A collection of text suitable for use in a full-text search index, semicolon delimited",
-            index=False,
+            default=None,
+            doc="A collection of text suitable for use in a full-text search index",
         ),
     )
     sample_description: Optional[str] = (
@@ -53,44 +55,49 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    context_categories: Optional[str] = (
-        Field(
-            default=None,
+    context_categories: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="The context categories from the iSamples controlled vocabulary, semicolon delimited",
-            index=False,
+            default=None,
+            doc="The context categories from the iSamples controlled vocabulary",
         ),
     )
-    material_categories: Optional[str] = (
-        Field(
-            default=None,
+    material_categories: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
-            index=False,
+            default=None,
+            doc="The material categories from the iSamples controlled vocabulary",
         ),
     )
-    specimen_categories: Optional[str] = (
-        Field(
-            default=None,
+    specimen_categories: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="The material categories from the iSamples controlled vocabulary, semicolon delimited",
-            index=False,
+            default=None,
+            doc="The specimen categories from the iSamples controlled vocabulary",
         ),
     )
-    keywords: Optional[str] = (
-        Field(
-            default=None,
+    keywords: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="Keywords for searching, semicolon delimited",
-            index=False,
+            default=None,
+            doc="Keywords for searching",
         ),
     )
-    informal_classification: Optional[str] = (
-        Field(
-            default=None,
+    informal_classifications: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="Informal scientific classification of the sample",
-            index=False,
+            default=None,
+            doc="Informal scientific classification of the sample",
         ),
     )
     produced_by_isb_core_id: Optional[str] = (
@@ -125,12 +132,13 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    produced_by_responsibility: Optional[str] = (
-        Field(
-            default=None,
+    produced_by_responsibilities: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="The name of the people or institution responsible for producing the sample, semicolon-delimited",
-            index=False,
+            default=None,
+            doc="The name of the people or institution responsible for producing the sample",
         ),
     )
     produced_by_result_time: Optional[str] = (
@@ -173,28 +181,31 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    produced_by_sampling_site_place_name: Optional[str] = (
-        Field(
-            default=None,
+    produced_by_sampling_site_place_names: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="The place name of the sampling site",
-            index=False,
+            default=None,
+            doc="The place names of the sampling site",
         ),
     )
-    registrant: Optional[str] = (
-        Field(
-            default=None,
+    registrants: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="The registrant of the sample",
-            index=False,
+            default=None,
+            doc="The registrants of the sample",
         ),
     )
-    sampling_purpose: Optional[str] = (
-        Field(
-            default=None,
+    sampling_purposes: Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="Why the sample was collected",
-            index=False,
+            default=None,
+            doc="Why the sample was collected",
         ),
     )
     curation_label: Optional[str] = (
@@ -237,12 +248,13 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    related_resources_isb_core_id: Optional[str] = (
-        Field(
-            default=None,
+    related_resources_isb_core_id:  Optional[list] = Field(
+        # Use the raw SQLAlchemy column in order to get the proper JSON behavior
+        sa_column=sqlalchemy.Column(
+            sqlalchemy.JSON,
             nullable=True,
-            description="Identifiers for related resources, semicolon-delimited",
-            index=False,
+            default=None,
+            doc="Identifiers for related resources",
         ),
     )
     source: Optional[str] = (

--- a/isb_lib/models/isb_core_record.py
+++ b/isb_lib/models/isb_core_record.py
@@ -173,11 +173,19 @@ class ISBCoreRecord(SQLModel, table=True):
             index=False,
         ),
     )
-    produced_by_sampling_site_location_ll: Optional[str] = (
+    produced_by_sampling_site_location_latitude: Optional[float] = (
         Field(
             default=None,
             nullable=True,
-            description="The latitude and longitude of the sampling site, in a comma-separated string",
+            description="The latitude of the sampling site",
+            index=False,
+        ),
+    )
+    produced_by_sampling_site_location_longitude: Optional[float] = (
+        Field(
+            default=None,
+            nullable=True,
+            description="The longitude of the sampling site",
             index=False,
         ),
     )

--- a/isb_web/isb_solr_query.py
+++ b/isb_web/isb_solr_query.py
@@ -580,7 +580,7 @@ class ISBCoreSolrRecordIterator:
     def __init__(
         self,
         rsession=requests.session(),
-        authority: str = None,
+        query: str = None,
         batch_size: int = 50000,
         offset: int = 0,
         sort: str = None,
@@ -595,7 +595,7 @@ class ISBCoreSolrRecordIterator:
             sort: The solr sort parameter to use
         """
         self.rsession = rsession
-        self.authority = authority
+        self.query = query
         self.batch_size = batch_size
         self.offset = offset
         self.sort = sort
@@ -611,11 +611,12 @@ class ISBCoreSolrRecordIterator:
         ):
             self._current_batch = _fetch_solr_records(
                 self.rsession,
-                self.authority,
+                None,
                 self.offset,
                 self.batch_size,
                 None,
                 self.sort,
+                self.query
             )[0]
             if len(self._current_batch) == 0:
                 # reached the end of the records

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -37,7 +37,9 @@ SOLR_TO_SQLITE_FIELD_MAPPINGS = {
     "curation_label": "curation_label",
     "curation_description": "curation_description",
     "curation_accessConstraints": "curation_access_constraints",
-    "curation_location": "curation_location"
+    "curation_location": "curation_location",
+    "curation_responsibility": "curation_responsibility",
+    "relatedResource_isb_core_id": "related_resources_isb_core_id"
 }
 
 NUMERIC_COLUMNS = ["produced_by_sampling_site_elevation_in_meters"]

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -1,0 +1,62 @@
+import click
+import click_config_file
+import isb_lib.core
+from isb_lib.models.isb_core_record import ISBCoreRecord
+from isb_web.isb_solr_query import ISBCoreSolrRecordIterator
+import requests
+from sqlmodel import SQLModel, create_engine, Session, select
+
+
+@click.command()
+@click.option(
+    "-d", "--db_url", default=None, help="The SQLite database file URL for storage.  Doesn't need to exist beforehand."
+)
+@click.option(
+    "-s", "--solr_url", default=None, help="Solr index URL"
+)
+@click.option(
+    "-v",
+    "--verbosity",
+    default="DEBUG",
+    help="Specify logging level",
+    show_default=True,
+)
+@click.option(
+    "-H", "--heart_rate", is_flag=True, help="Show heartrate diagnostics on 9999"
+)
+@click.option(
+    "-a",
+    "--authority",
+    default=None,
+    help="Which authority to use when selecting and dumping the resolved_content",
+)
+@click_config_file.configuration_option(config_file_name="isb.cfg")
+@click.pass_context
+def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
+    isb_lib.core.things_main(ctx, db_url, solr_url, verbosity, heart_rate)
+    engine = create_engine(ctx.obj["db_url"], echo=False)
+    SQLModel.metadata.drop_all(engine, tables=[ISBCoreRecord.__table__])
+    SQLModel.metadata.create_all(engine, tables=[ISBCoreRecord.__table__])
+    session = Session(engine)
+    total_records = 0
+    batch_size = 1000
+    rsession = requests.session()
+    iterator = ISBCoreSolrRecordIterator(rsession, authority, batch_size, 0, "id asc")
+    for record in iterator:
+        # These bookkeeping fields in solr shouldn't end up in the dump
+        record.pop("_version_", None)
+        record.pop("producedBy_samplingSite_location_bb__minY", None)
+        record.pop("producedBy_samplingSite_location_bb__minX", None)
+        record.pop("producedBy_samplingSite_location_bb__maxY", None)
+        record.pop("producedBy_samplingSite_location_bb__maxX", None)
+        new_record = ISBCoreRecord()
+        new_record.id = record["id"]
+        session.add(new_record)
+        session.commit()
+
+
+"""
+Dumps the iSamples in a Box Solr Core records to a SQLite file
+"""
+if __name__ == "__main__":
+    main()

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -94,52 +94,41 @@ def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
     batch_size = 50000
     session_commit_frequency = 50000
     rsession = requests.session()
-    with cProfile.Profile() as pr:
-        iterator = ISBCoreSolrRecordIterator(rsession, authority, batch_size, 0, "id asc")
-        iterator.__next__()
-        pr.enable()
-        num_records = 0
-        current_batch = []
-        for solr_record in iterator:
-            # We ended up using the core API as creating new records was too slow…
-            # https://docs.sqlalchemy.org/en/14/core/tutorial.html
-            # new_record = ISBCoreRecord()
-            new_record = {}
-            for key, value in SOLR_TO_SQLITE_FIELD_MAPPINGS.items():
-                solr_value = solr_record.get(key)
-                if type(solr_value) is list:
-                    filtered_solr_values = [_filtered_value(value) for value in solr_value]
-                    solr_value = "; ".join(filtered_solr_values)
-                elif type(solr_value) is str:
-                    # Don't include placeholder empty values in the dump
-                    solr_value = _filtered_value(solr_value)
-                # Key is source column solr name, value is dest column sqlite name in sqlite
-                if solr_value is not None:
-                    new_record[value] = solr_value
+    iterator = ISBCoreSolrRecordIterator(rsession, authority, batch_size, 0, "id asc")
+    num_records = 0
+    current_batch = []
+    for solr_record in iterator:
+        # We ended up using the core API as creating new records was too slow…
+        # https://docs.sqlalchemy.org/en/14/core/tutorial.html
+        # new_record = ISBCoreRecord()
+        new_record = {}
+        for key, value in SOLR_TO_SQLITE_FIELD_MAPPINGS.items():
+            solr_value = solr_record.get(key)
+            if type(solr_value) is list:
+                filtered_solr_values = [_filtered_value(value) for value in solr_value]
+                solr_value = "; ".join(filtered_solr_values)
+            elif type(solr_value) is str:
+                # Don't include placeholder empty values in the dump
+                solr_value = _filtered_value(solr_value)
+            # Key is source column solr name, value is dest column sqlite name in sqlite
+            if solr_value is not None:
+                new_record[value] = solr_value
+            else:
+                # There was weirdness here where if we set None, the insert statement broke.  A hack!
+                if value in NUMERIC_COLUMNS:
+                    new_record[value] = 0.0
                 else:
-                    # There was weirdness here where if we set None, the insert statement broke.  A hack!
-                    if value in NUMERIC_COLUMNS:
-                        new_record[value] = 0.0
-                    else:
-                        new_record[value] = ""
-            current_batch.append(new_record)
-            num_records += 1
-            if num_records % session_commit_frequency == 0:
-                logging.info(f"Committing records, have processed {num_records}")
-                session.bulk_insert_mappings(mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False)
-                session.commit()
-                current_batch = []
-            if num_records == 5000:
-                break
-            # Commit any remainder
-        session.commit()
-        s = io.StringIO()
-        ps = pstats.Stats(pr, stream=s).sort_stats(SortKey.CUMULATIVE)
-        # ps.strip_dirs()
-        ps.print_stats()
-        print(s.getvalue())
-        ps.print_callers()
-        print(s.getvalue())
+                    new_record[value] = ""
+        current_batch.append(new_record)
+        num_records += 1
+        if num_records % session_commit_frequency == 0:
+            logging.info(f"Committing records, have processed {num_records}")
+            session.bulk_insert_mappings(mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False)
+            session.commit()
+            current_batch = []
+    # Commit any remainder
+    session.bulk_insert_mappings(mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False)
+    session.commit()
 
 
 """

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -1,3 +1,5 @@
+import json
+
 import click
 import click_config_file
 import isb_lib.core
@@ -7,10 +9,6 @@ from isb_web.isb_solr_query import ISBCoreSolrRecordIterator
 import requests
 from sqlmodel import SQLModel, create_engine, Session
 import logging
-import cProfile
-import pstats
-from pstats import SortKey
-import io
 
 # Use this to map between the solr column names and the sqlite column names and control what is
 # written to the dump.
@@ -26,20 +24,20 @@ SOLR_TO_SQLITE_FIELD_MAPPINGS = {
     "hasMaterialCategory": "material_categories",
     "hasSpecimenCategory": "specimen_categories",
     "keywords": "keywords",
-    "informalClassification": "informal_classification",
+    "informalClassification": "informal_classifications",
     "producedBy_isb_core_id": "produced_by_isb_core_id",
     "producedBy_label": "produced_by_label",
     "producedBy_description": "produced_by_description",
     "producedBy_hasFeatureOfInterest": "produced_by_feature_of_interest",
-    "producedBy_responsibility": "produced_by_responsibility",
+    "producedBy_responsibility": "produced_by_responsibilities",
     "producedBy_resultTime": "produced_by_result_time",
     "producedBy_samplingSite_description": "produced_by_sampling_site_description",
     "producedBy_samplingSite_label": "produced_by_sampling_site_label",
     "producedBy_samplingSite_location_elevationInMeters": "produced_by_sampling_site_elevation_in_meters",
     "producedBy_samplingSite_location_ll": "produced_by_sampling_site_location_ll",
-    "producedBy_samplingSite_placeName": "produced_by_sampling_site_place_name",
-    "registrant": "registrant",
-    "samplingPurpose": "sampling_purpose",
+    "producedBy_samplingSite_placeName": "produced_by_sampling_site_place_names",
+    "registrant": "registrants",
+    "samplingPurpose": "sampling_purposes",
     "curation_label": "curation_label",
     "curation_description": "curation_description",
     "curation_accessConstraints": "curation_access_constraints",
@@ -106,7 +104,7 @@ def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
             solr_value = solr_record.get(key)
             if type(solr_value) is list:
                 filtered_solr_values = [_filtered_value(value) for value in solr_value]
-                solr_value = "; ".join(filtered_solr_values)
+                solr_value = json.dumps(filtered_solr_values)
             elif type(solr_value) is str:
                 # Don't include placeholder empty values in the dump
                 solr_value = _filtered_value(solr_value)

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -34,7 +34,8 @@ SOLR_TO_SQLITE_FIELD_MAPPINGS = {
     "producedBy_samplingSite_description": "produced_by_sampling_site_description",
     "producedBy_samplingSite_label": "produced_by_sampling_site_label",
     "producedBy_samplingSite_location_elevationInMeters": "produced_by_sampling_site_elevation_in_meters",
-    "producedBy_samplingSite_location_ll": "produced_by_sampling_site_location_ll",
+    "producedBy_samplingSite_location_latitude": "produced_by_sampling_site_location_latitude",
+    "producedBy_samplingSite_location_longitude": "produced_by_sampling_site_location_longitude",
     "producedBy_samplingSite_placeName": "produced_by_sampling_site_place_names",
     "registrant": "registrants",
     "samplingPurpose": "sampling_purposes",
@@ -44,10 +45,14 @@ SOLR_TO_SQLITE_FIELD_MAPPINGS = {
     "curation_location": "curation_location",
     "curation_responsibility": "curation_responsibility",
     "relatedResource_isb_core_id": "related_resources_isb_core_id",
-    "source": "source"
+    "source": "source",
 }
 
-NUMERIC_COLUMNS = ["produced_by_sampling_site_elevation_in_meters"]
+NUMERIC_COLUMNS = [
+    "produced_by_sampling_site_elevation_in_meters",
+    "producedBy_samplingSite_location_latitude",
+    "producedBy_samplingSite_location_longitude",
+]
 
 
 # Filter out any placeholder values that shouldn't appear in the dump
@@ -121,11 +126,15 @@ def main(ctx, db_url, solr_url, verbosity, heart_rate, query):
         num_records += 1
         if num_records % session_commit_frequency == 0:
             logging.info(f"Committing records, have processed {num_records}")
-            session.bulk_insert_mappings(mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False)
+            session.bulk_insert_mappings(
+                mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False
+            )
             session.commit()
             current_batch = []
     # Commit any remainder
-    session.bulk_insert_mappings(mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False)
+    session.bulk_insert_mappings(
+        mapper=ISBCoreRecord, mappings=current_batch, return_defaults=False
+    )
     session.commit()
 
 

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -76,14 +76,14 @@ def _filtered_value(value):
     "-H", "--heart_rate", is_flag=True, help="Show heartrate diagnostics on 9999"
 )
 @click.option(
-    "-a",
-    "--authority",
+    "-q",
+    "--query",
     default=None,
-    help="Which authority to use when selecting and dumping the resolved_content",
+    help="The solr query to use when fetching the records for the dump",
 )
 @click_config_file.configuration_option(config_file_name="isb.cfg")
 @click.pass_context
-def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
+def main(ctx, db_url, solr_url, verbosity, heart_rate, query):
     isb_lib.core.things_main(ctx, db_url, solr_url, verbosity, heart_rate)
     engine = create_engine(ctx.obj["db_url"], echo=False)
     SQLModel.metadata.drop_all(engine, tables=[ISBCoreRecord.__table__])
@@ -92,7 +92,7 @@ def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
     batch_size = 50000
     session_commit_frequency = 50000
     rsession = requests.session()
-    iterator = ISBCoreSolrRecordIterator(rsession, authority, batch_size, 0, "id asc")
+    iterator = ISBCoreSolrRecordIterator(rsession, query, batch_size, 0, "id asc")
     num_records = 0
     current_batch = []
     for solr_record in iterator:

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -116,6 +116,8 @@ def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
         if num_records % session_commit_frequency == 0:
             logging.info(f"Committing records, have processed {num_records}")
             session.commit()
+    # Commit any remainder
+    session.commit()
 
 
 """

--- a/scripts/create_sql_lite_dump.py
+++ b/scripts/create_sql_lite_dump.py
@@ -1,10 +1,53 @@
 import click
 import click_config_file
 import isb_lib.core
+from isamples_metadata import Transformer
 from isb_lib.models.isb_core_record import ISBCoreRecord
 from isb_web.isb_solr_query import ISBCoreSolrRecordIterator
 import requests
-from sqlmodel import SQLModel, create_engine, Session, select
+from sqlmodel import SQLModel, create_engine, Session
+
+# Use this to map between the solr column names and the sqlite column names and control what is
+# written to the dump.
+SOLR_TO_SQLITE_FIELD_MAPPINGS = {
+    "id": "id",
+    "isb_core_id": "isb_core_id",
+    "indexUpdatedTime": "isb_updated_time",
+    "sourceUpdatedTime": "source_updated_time",
+    "label": "label",
+    "searchText": "search_text",
+    "description": "sample_description",
+    "hasContextCategory": "context_categories",
+    "hasMaterialCategory": "material_categories",
+    "hasSpecimenCategory": "specimen_categories",
+    "keywords": "keywords",
+    "informalClassification": "informal_classification",
+    "producedBy_isb_core_id": "produced_by_isb_core_id",
+    "producedBy_label": "produced_by_label",
+    "producedBy_description": "produced_by_description",
+    "producedBy_hasFeatureOfInterest": "produced_by_feature_of_interest",
+    "producedBy_responsibility": "produced_by_responsibility",
+    "producedBy_resultTime": "produced_by_result_time",
+    "producedBy_samplingSite_description": "produced_by_sampling_site_description",
+    "producedBy_samplingSite_label": "produced_by_sampling_site_label",
+    "producedBy_samplingSite_location_elevationInMeters": "produced_by_sampling_site_elevation_in_meters",
+    "producedBy_samplingSite_placeName": "produced_by_sampling_site_place_name",
+    "registrant": "registrant",
+    "samplingPurpose": "sampling_purpose",
+    "curation_label": "curation_label",
+    "curation_description": "curation_description",
+    "curation_accessConstraints": "curation_access_constraints",
+    "curation_location": "curation_location"
+}
+
+NUMERIC_COLUMNS = ["produced_by_sampling_site_elevation_in_meters"]
+
+
+# Filter out any placeholder values that shouldn't appear in the dump
+def _filtered_value(value):
+    if type(value) is str and value == Transformer.NOT_PROVIDED:
+        return ""
+    return value
 
 
 @click.command()
@@ -38,19 +81,28 @@ def main(ctx, db_url, solr_url, verbosity, heart_rate, authority):
     SQLModel.metadata.drop_all(engine, tables=[ISBCoreRecord.__table__])
     SQLModel.metadata.create_all(engine, tables=[ISBCoreRecord.__table__])
     session = Session(engine)
-    total_records = 0
     batch_size = 1000
     rsession = requests.session()
     iterator = ISBCoreSolrRecordIterator(rsession, authority, batch_size, 0, "id asc")
-    for record in iterator:
-        # These bookkeeping fields in solr shouldn't end up in the dump
-        record.pop("_version_", None)
-        record.pop("producedBy_samplingSite_location_bb__minY", None)
-        record.pop("producedBy_samplingSite_location_bb__minX", None)
-        record.pop("producedBy_samplingSite_location_bb__maxY", None)
-        record.pop("producedBy_samplingSite_location_bb__maxX", None)
+    for solr_record in iterator:
         new_record = ISBCoreRecord()
-        new_record.id = record["id"]
+        for key, value in SOLR_TO_SQLITE_FIELD_MAPPINGS.items():
+            solr_value = solr_record.get(key)
+            if type(solr_value) is list:
+                filtered_solr_values = [_filtered_value(value) for value in solr_value]
+                solr_value = "; ".join(filtered_solr_values)
+            elif type(solr_value) is str:
+                # Don't include placeholder empty values in the dump
+                solr_value = _filtered_value(solr_value)
+            # Key is source column solr name, value is dest column sqlite name in sqlite
+            if solr_value is not None:
+                new_record.__setattr__(value, solr_value)
+            else:
+                # There was weirdness here where if we set None, the insert statement broke.  A hack!
+                if value in NUMERIC_COLUMNS:
+                    new_record.__setattr__(value, 0.0)
+                if value != "produced_by_sampling_site_elevation_in_meters":
+                    new_record.__setattr__(value, "")
         session.add(new_record)
         session.commit()
 


### PR DESCRIPTION
As requested by @hongcui, we'd like an easy to consume dump of our ISB Core records.  We already had https://github.com/isamplesorg/isamples_inabox/issues/78, so it seemed like a good time to take care of two things at once.

Implementation ends up being pretty straightforward -- create a SQLModel and use each row of solr results to create a new model object then save it with SQLAlchemy.