### PR TITLE
Issue 142

### DIFF
--- a/isb_web/isb_solr_query.py
+++ b/isb_web/isb_solr_query.py
@@ -58,6 +58,7 @@ ALLOWED_SELECT_METHODS = [
 
 L = logging.getLogger("ISB_SOLR_QUERY")
 
+
 def escape_solr_query_term(term):
     """Escape a query term for inclusion in a query."""
     term = term.replace("\\", "\\\\")

--- a/isb_web/isb_solr_query.py
+++ b/isb_web/isb_solr_query.py
@@ -391,7 +391,7 @@ def solr_searchStream(params, collection="isb_core_records"):  # noqa: C901
     Sorting by distance from a location can be done with the geodist() function, however the
     function result must be included in the streaming response field list.
 
-    For example, given latitude=-17.47833 and longtiude=-149.92189, a request
+    For example, given latitude=-17.47833 and longitude=-149.92189, a request
     to stream results in order of distance from that location:
 
         gdfunc=geodist(producedBy_samplingSite_location_ll,-17.47833,-149.92189)
@@ -408,6 +408,8 @@ def solr_searchStream(params, collection="isb_core_records"):  # noqa: C901
     curl --data-urlencode \
       'expr=search(isb_core_records,q="source:SESAR",fq="searchText:sample",fq="hasMaterialCategory:Mineral",fl="id,producedBy_samplingSite_location_latitude,producedBy_samplingSite_location_longitude",sort="id asc",qt="/export")'\
       "http://localhost:8983/solr/isb_core_records/stream"
+
+    For the ISB solr schema configuration, geodist() returns results in km.
 
     Args:
         params: list of [k,v], the parameters for the stream expression

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -387,9 +387,13 @@ async def get_solr_stream(request: fastapi.Request):
         ],
         "rows": isb_solr_query.MAX_STREAMING_ROWS,
         "start": 0,
-        "select":"search",
-        "xycount": False,  #if true, return counts per location
-        "onlyxy": True,    #if true, return only records with latitude,longitude
+        "select": "search",
+
+        # if true, return counts per location
+        "xycount": False,
+
+        # if true, return only records with latitude,longitude
+        "onlyxy": True,
     }
     properties = {
         "q": defparams["q"]
@@ -401,7 +405,7 @@ async def get_solr_stream(request: fastapi.Request):
         if k in properties:
             properties[k] = v
     params = set_default_params(params, defparams)
-    #L.debug("Params: %s", params)
+    # L.debug("Params: %s", params)
     analytics.record_analytics_event(AnalyticsEvent.THING_SOLR_STREAM, request, properties)
     return isb_solr_query.solr_searchStream(params)
 

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -318,7 +318,7 @@ def set_default_params(params, defs):
 async def get_solr_select(request: fastapi.Request):
     """Send select request to the Solr isb_core_records collection.
 
-    See https://solr.apache.org/guide/8_9/common-query-parameters.html
+    See https://solr.apache.org/guide/8_11/common-query-parameters.html
     """
     # Construct a list of K,V pairs to hand on to the solr request.
     # Can't use a standard dict here because we need to support possible
@@ -360,9 +360,50 @@ async def get_solr_query(
 
 @app.get(f"/{THING_URL_PATH}/stream", response_model=typing.Any)
 async def get_solr_stream(request: fastapi.Request):
-    # logging.warning("Query params: ", request.query_params)
-    analytics.record_analytics_event(AnalyticsEvent.THING_SOLR_STREAM, request)
-    return isb_solr_query.solr_searchStream(request.query_params)
+    '''
+    Make a streaming request to the solr index.
+
+    The Solr streaming API offers much richer interaction with the index, though
+    also adds risk that a request may perform harmful actions. Here only
+    search expressions are constructed from parameters similar to the select API
+    to limit potential harm to the index.
+
+    See https://solr.apache.org/guide/8_11/streaming-expressions.html
+
+    Args:
+        request: The http request
+
+    Returns:
+        fastapi.responses.StreamingResponse
+    '''
+    # Note that there may be duplicate keys in params, e.g. multiple fq=
+    defparams = {
+        "wt": "json",
+        "q": "*:*",
+        "fl": [
+            "id",
+            f"x:{isb_solr_query.LONGITUDE_FIELD}",
+            f"y:{isb_solr_query.LATITUDE_FIELD}",
+        ],
+        "rows": isb_solr_query.MAX_STREAMING_ROWS,
+        "start": 0,
+        "select":"search",
+        "xycount": False,  #if true, return counts per location
+        "onlyxy": True,    #if true, return only records with latitude,longitude
+    }
+    properties = {
+        "q": defparams["q"]
+    }
+    params = []
+    # Update params with the provided parameters
+    for k, v in request.query_params.multi_items():
+        params.append([k, v])
+        if k in properties:
+            properties[k] = v
+    params = set_default_params(params, defparams)
+    #L.debug("Params: %s", params)
+    analytics.record_analytics_event(AnalyticsEvent.THING_SOLR_STREAM, request, properties)
+    return isb_solr_query.solr_searchStream(params)
 
 
 @app.get(f"/{THING_URL_PATH}/select/info", response_model=typing.Any)


### PR DESCRIPTION
Adds support for duplicate parameters (e.g. multiple `fq=` params) in requests to the streaming API