### PR TITLE
Workaround duplicate insert bug

### DIFF
--- a/scripts/consume_sitemaps.py
+++ b/scripts/consume_sitemaps.py
@@ -275,6 +275,8 @@ def fetch_sitemap_files(
                     db_session.bulk_update_mappings(
                         mapper=Thing, mappings=current_existing_things_batch
                     )
+                    current_existing_things_batch = []
+                    current_new_things_batch = []
                     db_session.commit()
                     logging.info(
                         f"Just processed {len(things_fetcher.json_things)} things"


### PR DESCRIPTION
@datadavev this is my best guess as to why that integrity constraint violation was occurring.  I can't reproduce locally but I think it's because my machine is too fast, to reproduce I think we'd need the futures to bump into one another