### PR TITLE
Guard against degenerate Things

### DIFF
--- a/scripts/migrations/populate_h3_for_existing_things.py
+++ b/scripts/migrations/populate_h3_for_existing_things.py
@@ -63,9 +63,12 @@ def assign_h3(session: Session):
             for row in results:
                 i += 1
                 primary_key = row[0]
-                h3 = geo_to_h3(row[1])
-                if h3 is not None:
-                    update_batch_values.append({"primary_key": primary_key, "h3": h3})
+                # Guard against degenerate records in the database -- could happen if there are problems with the
+                # initial import
+                if row[1] is not None:
+                    h3 = geo_to_h3(row[1])
+                    if h3 is not None:
+                        update_batch_values.append({"primary_key": primary_key, "h3": h3})
                 last_id = primary_key
             # It's possible the length could be 0 since we don't have lat/lon for all records
             if len(update_batch_values) > 0:


### PR DESCRIPTION
Encountered an error populating h3 on the SESAR box:

```
Traceback (most recent call last):
  File "/app/scripts/migrations/populate_h3_for_existing_things.py", line 100, in <module>
    main()
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/app/scripts/migrations/populate_h3_for_existing_things.py", line 39, in main
    assign_h3(session)
  File "/app/scripts/migrations/populate_h3_for_existing_things.py", line 66, in assign_h3
    h3 = geo_to_h3(row[1])
  File "/app/isamples_metadata/SESARTransformer.py", line 504, in geo_to_h3
    return isamples_metadata.Transformer.geo_to_h3(_content_latitude(content), _content_longitude(content))
  File "/app/isamples_metadata/SESARTransformer.py", line 496, in _content_latitude
    return _geo_location_float_value(source_record, "latitude")
  File "/app/isamples_metadata/SESARTransformer.py", line 477, in _geo_location_float_value
    description = source_record.get("description")
AttributeError: 'NoneType' object has no attribute 'get'
```

there are rows in that db that represent Things with no content.  Guard against that.