### PR TITLE
Implement code exchange for token

### DIFF
--- a/isb_lib/authorization/orcid/__init__.py
+++ b/isb_lib/authorization/orcid/__init__.py
@@ -1,12 +1,22 @@
 import logging
+from typing import Optional
 
 import requests
 from requests import Response
+from isb_web import config
 
 ORCID_API_CONTENT_TYPE = "application/orcid+json"
 ORCID_API_VERSION = "2.1"
 ORCID_API_ENDPOINT = "record"
-ORCID_API_HOSTNAME = "pub.sandbox.orcid.org"
+ORCID_API_HOSTNAME = config.Settings().orcid_hostname
+ORCID_TOKEN_REDIRECT_URI = config.Settings().orcid_token_redirect_uri
+ORCID_CLIENT_ID = config.Settings().orcid_client_id
+ORCID_CLIENT_SECRET = config.Settings().orcid_client_secret
+ORCID_CODE_GRANT_TYPE = "authorization_code"
+
+
+def _orcid_token_url():
+    return f"https://{ORCID_API_HOSTNAME}/oauth/token"
 
 
 def _orcid_auth_url(orcid_id: str) -> str:
@@ -38,3 +48,32 @@ def authorize_token_for_orcid_id(
             f"Error checking token {token} for orcid {orcid_id}, response: {response.json()}"
         )
         return False
+
+
+def _orcid_post_body(code: str) -> dict:
+    return {
+        "code": code,
+        "redirect_uri": ORCID_TOKEN_REDIRECT_URI,
+        "client_id": ORCID_CLIENT_ID,
+        "client_secret": ORCID_CLIENT_SECRET,
+        "grant_type": ORCID_CODE_GRANT_TYPE,
+    }
+
+
+def _orcid_token_response(rsession: requests.Session, code: str) -> Response:
+    body = _orcid_post_body(code)
+    response = rsession.post(_orcid_token_url(), data=body)
+    return response
+
+
+def exchange_code_for_token(
+    code: str, rsession: requests.Session = requests.session()
+) -> Optional[dict]:
+    response = _orcid_token_response(rsession, code)
+    if response.status_code == 200:
+        return response.json()
+    else:
+        logging.error(
+            f"Error converting authorization code: {code} to token.  Response: {response.json()}"
+        )
+        return None

--- a/isb_web/config.py
+++ b/isb_web/config.py
@@ -63,5 +63,16 @@ class Settings(BaseSettings):
     # The URL to the datacite API
     datacite_url: str = "https://api.test.datacite.org/"
 
+    orcid_hostname: str = "pub.sandbox.orcid.org"
+
+    orcid_token_redirect_uri: str = "http://localhost:8000/orcid_token"
+
+    # This shouldn't be checked in.  Set it by doing export export ORCID_CLIENT_ID=foobar
+    orcid_client_id: str = ""
+
+    # This must not ever be checked in.  Set it by doing export export ORCID_CLIENT_SECRET=foobar
+    orcid_client_secret: str = ""
+
     class Config:
         env_file = "isb_web_config.env"
+        case_sensitive = False

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -8,6 +8,19 @@ from isb_lib.authorization import orcid
 # https://stackoverflow.com/questions/42708389/how-to-set-environment-variables-in-pycharm
 orcid_id = os.environ.get("TEST_ORCID_ID")
 token = os.environ.get("TEST_ORCID_TOKEN")
+code = os.environ.get("TEST_ORCID_CODE")
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") is not None, reason="Don't run live requests in CI"
+)
+def test_authorize_token():
+    """Manual integration test useful for running things against a live endpoint.  Inappropriate for unit testing,
+    but helpful as a smoke test to make sure all the pieces fit together.  You'll need to manually generate a token
+    and orcid via the instructions here: https://orcid.github.io/orcid-api-tutorial/get/ -- The Google OAuth 2.0
+    Playground route was easy to use and worked well in Chrome."""
+    authorized = orcid.authorize_token_for_orcid_id(token, orcid_id)
+    assert authorized
 
 
 @pytest.mark.skipif(
@@ -15,11 +28,11 @@ token = os.environ.get("TEST_ORCID_TOKEN")
 )
 def test_integration():
     """Manual integration test useful for running things against a live endpoint.  Inappropriate for unit testing,
-    but helpful as a smoke test to make sure all the pieces fit together.  You'll need to manually generate a token
-    and orcid via the instructions here: https://orcid.github.io/orcid-api-tutorial/get/ -- The Google OAuth 2.0
+    but helpful as a smoke test to make sure all the pieces fit together.  You'll need to manually generate a code
+    via the instructions here: https://orcid.github.io/orcid-api-tutorial/get/ -- The Google OAuth 2.0
     Playground route was easy to use and worked well in Chrome."""
-    authorized = orcid.authorize_token_for_orcid_id(token, orcid_id)
-    assert authorized
+    token_payload = orcid.exchange_code_for_token(code)
+    assert token_payload is not None and len(token_payload) > 0
 
 
 def test_url():
@@ -33,3 +46,10 @@ def test_headers():
     headers = orcid._orcid_auth_headers(test_token)
     assert test_token in headers.get("Authorization")
     assert headers.get("Content-Type") is not None
+
+
+def test_post_body():
+    code = "test_code"
+    post_body = orcid._orcid_post_body(code)
+    assert "code" in post_body
+    assert post_body.get("code") == code


### PR DESCRIPTION
Per discussion with @qgan7125, implement a fastapi method that receives the code from a redirect URI and calls over to orcid to turn it into a token payload.

Though this will change as we build up more of the supporting code, I tested like this:

- Created an account on https://sandbox.orcid.org/developer-tools
- Added an app using the public API, and added "http://localhost:8000/orcid_token" as a redirect URI
- Set the app id and secret using the `ORCID_CLIENT_ID` and `ORCID_CLIENT_SECRET` environment variables when running python
- Logged in to the orcid developer site, and copied the authorize request url, after selecting http://localhost:8000/orcid_token as the redirect URI
- Pasted the authorize request url into Chrome
- See token output in browser, verify Cookies are set as expected