### PR TITLE
Review feedback: move token to a header rather than post body

### DIFF
--- a/isb_lib/authorization/orcid/__init__.py
+++ b/isb_lib/authorization/orcid/__init__.py
@@ -24,7 +24,11 @@ def _orcid_auth_url(orcid_id: str) -> str:
 
 
 def _orcid_auth_headers(token: str) -> dict:
-    return {"Content-Type": ORCID_API_CONTENT_TYPE, "Authorization": f"Bearer {token}"}
+    # Be flexible about downstream clients including the Bearer prefix or not
+    bearer_prefix = "Bearer "
+    if not token.startswith(bearer_prefix):
+        token = f"{bearer_prefix}{token}"
+    return {"Content-Type": ORCID_API_CONTENT_TYPE, "Authorization": token}
 
 
 def _orcid_auth_response(

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -238,7 +238,6 @@ def get_orcid_token(request: fastapi.Request, response: fastapi.Response):
 
 
 class MintIdentifierParams(BaseModel):
-    token: str
     orcid_id: str
     datacite_metadata: dict
 
@@ -251,7 +250,10 @@ def mint_identifier(request: fastapi.Request, params: MintIdentifierParams):
         params: Class that contains the credentials and the data to post to datacite
     Return: The minted identifier
     """
-    authorized = orcid.authorize_token_for_orcid_id(params.token, params.orcid_id)
+    token = request.headers.get("Authorization")
+    authorized = False
+    if token is not None and params.orcid_id is not None:
+        authorized = orcid.authorize_token_for_orcid_id(token, params.orcid_id)
     if not authorized:
         raise HTTPException(status_code=401, detail="Invalid orcid id or token")
     post_data = json.dumps(params.datacite_metadata).encode("utf-8")

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -48,6 +48,15 @@ def test_headers():
     assert headers.get("Content-Type") is not None
 
 
+def test_authorization_preserves_bearer():
+    test_token = "foobar"
+    expected_token_value = f"Bearer {test_token}"
+    headers = orcid._orcid_auth_headers(test_token)
+    assert headers.get("Authorization") == expected_token_value
+    headers = orcid._orcid_auth_headers(expected_token_value)
+    assert headers.get("Authorization") == expected_token_value
+
+
 def test_post_body():
     code = "test_code"
     post_body = orcid._orcid_post_body(code)


### PR DESCRIPTION
Review feedback from @datadavev -- make the auth not be in the post body, use a header instead