### PR TITLE
Fix GEOME h3 calculation where lat/lon were reversed

### DIFF
--- a/isamples_metadata/GEOMETransformer.py
+++ b/isamples_metadata/GEOMETransformer.py
@@ -546,4 +546,4 @@ def _content_longitude(content: typing.Dict) -> typing.Optional[float]:
 
 
 def geo_to_h3(content: typing.Dict) -> typing.Optional[str]:
-    return isamples_metadata.Transformer.geo_to_h3(_content_longitude(content), _content_longitude(content))
+    return isamples_metadata.Transformer.geo_to_h3(_content_latitude(content), _content_longitude(content))

--- a/tests/test_isamples_metadata.py
+++ b/tests/test_isamples_metadata.py
@@ -10,7 +10,7 @@ import re
 import isamples_metadata.GEOMETransformer
 from isamples_metadata import Transformer
 from isamples_metadata.SESARTransformer import SESARTransformer
-from isamples_metadata.GEOMETransformer import GEOMETransformer, GEOMEChildTransformer
+from isamples_metadata.GEOMETransformer import GEOMETransformer, GEOMEChildTransformer, geo_to_h3 as geome_geo_to_h3
 from isamples_metadata.OpenContextTransformer import OpenContextTransformer
 from isamples_metadata.SmithsonianTransformer import SmithsonianTransformer
 
@@ -221,3 +221,11 @@ def test_smithsonian_dicts_equal(isamples_path):
 def test_geo_to_h3():
     h3 = Transformer.geo_to_h3(32.253460, -110.911789)
     assert h3 is not None
+
+
+def test_geome_geo_to_h3():
+    test_file_path = "./test_data/GEOME/raw/ark-21547-Car2PIRE_0334.json"
+    with open(test_file_path) as source_file:
+        source_record = json.load(source_file)
+        h3 = geome_geo_to_h3(source_record)
+        assert "8f65534b37a2c0d" == h3


### PR DESCRIPTION
Should be pretty self-explanatory, will need to re-run all the indexers manually