### PR TITLE
Add more documentation on model download and restore dependency 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -455,6 +455,18 @@ python-versions = "*"
 devel = ["colorama", "jsonschema", "json-spec", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
 
 [[package]]
+name = "fasttext"
+version = "0.9.2"
+description = "fasttext Python bindings"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+pybind11 = ">=2.2"
+
+[[package]]
 name = "filelock"
 version = "3.7.1"
 description = "A platform independent file lock."
@@ -1271,6 +1283,17 @@ description = "ASN.1 types and codecs"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pybind11"
+version = "2.10.0"
+description = "Seamless operability between C++11 and Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+global = ["pybind11-global (==2.10.0)"]
 
 [[package]]
 name = "pycares"
@@ -2111,7 +2134,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "fb69c917940528940908b89a219d09e9cb8dbeb771b7d539343ff5f450fef314"
+content-hash = "9463810006abc43d830174c380172cbc352503d84f362942e865d2a98c0a876a"
 
 [metadata.files]
 accept-types = [
@@ -2475,6 +2498,9 @@ fastapi = [
 fastjsonschema = [
     {file = "fastjsonschema-2.16.1-py3-none-any.whl", hash = "sha256:2f7158c4de792555753d6c2277d6a2af2d406dfd97aeca21d17173561ede4fe6"},
     {file = "fastjsonschema-2.16.1.tar.gz", hash = "sha256:d6fa3ffbe719768d70e298b9fb847484e2bdfdb7241ed052b8d57a9294a8c334"},
+]
+fasttext = [
+    {file = "fasttext-0.9.2.tar.gz", hash = "sha256:665556f1f6dcb4fcbe25fa8ebcd4f71b18fa96a090de09d88d97a60cbd29dcb5"},
 ]
 filelock = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
@@ -3203,6 +3229,10 @@ pyasn1 = [
     {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
     {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pybind11 = [
+    {file = "pybind11-2.10.0-py3-none-any.whl", hash = "sha256:6bbc7a2f79689307f0d8d240172851955fc214b33e4cbd7fdbc9cd7176a09260"},
+    {file = "pybind11-2.10.0.tar.gz", hash = "sha256:18977589c10f595f65ec1be90b0a0763b43e458d25d97be9db75b958eb1f43fe"},
 ]
 pycares = [
     {file = "pycares-4.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d83f193563b42360528167705b1c7bb91e2a09f990b98e3d6378835b72cd5c96"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ itsdangerous = "^2.1.2"
 starlette-oauth2-api = "^0.2.6"
 httpx = "^0.20.0"
 
-# fasttext = "^0.9.2"
+fasttext = "^0.9.2"  # for window users,  use fasttext-wheel = "^0.9.2"
 regex = "2022.3.2"
 h3 = "^3.7.4"
 aiodns = "3.0.0"

--- a/scripts/taxonomy/classification.py
+++ b/scripts/taxonomy/classification.py
@@ -62,7 +62,9 @@ def parse_SESAR_thing(thing):
 
 # output the classification result
 def get_classification_result(input, modelType, labelType):
-    # load the model
+    # model checkpoint can be downloaded at
+    # https://drive.google.com/drive/folders/1FreG1_ivysxPMXH0httxw4Ihftx-R2N6
+    # config file should have "FINE_TUNED_MODEL" : path/to/model/checkpoint
     if modelType == "SESAR" and labelType == "material":
         model = get_model("scripts/taxonomy/assets/SESAR_material_config.json")
     return model.predict(input)


### PR DESCRIPTION
Add instructions on downloading model checkpoint and restore the `fasttext` dependency for use in SMITHSONIAN classificaiton. 