### PR TITLE
Make sure we check out submodules when setting up our integration test environment

### DIFF
--- a/.github/workflows/python-integration-test.yaml
+++ b/.github/workflows/python-integration-test.yaml
@@ -20,6 +20,8 @@
      steps:
      - name: Checkout     
        uses: actions/checkout@v2
+       with:
+         submodules: recursive
      - name: Set up Python ${{ matrix.python-version }}
        uses: actions/setup-python@v2
        with:


### PR DESCRIPTION
After all that back and for this morning, @datadavev, I think this was the *actual* cause of the integration test failing.  Maybe there were multiple, I'm not sure, but I merged that other PR on Wednesday and I think that made things fail.