### PR TITLE
Clarify the documentation about how to load up the data for testing purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ brew services start postgres
 brew services start solr
 ```
 
+### Running the iSamples Central Postgres db locally
+Given that the iSamples Central database is pretty large, you'll want to start with a dump of the existing iSamples Central database rather than attempting to recreate it by hand.  Note that these steps do take quite some time to run, so don't be alarmed if it seems like nothing is happening.
+
+The first thing you'll want to do is dump the postgres database (or grab it from `/var/local/data/` on mars.cyverse.org).  The following command will dump an existing iSC postgres database and create a `.sql` file that you will load up in your local database:
+
+`pg_dump -a -U isb_writer -h localhost -d isb_1 > isamples_data_only.sql` -- note that the `-a` switch specifies data-only.  Given the history of the project and the rate at which things change, it is safer to *not* include the table creation statements in the dumped .sql file.
+
+Then, you'll want to transfer that dumped file to your local machine.  It's likely faster to gzip it first on the server and gunzip it locally.  Once you've transferred to your local machine, bringing up a local Docker iSB container will create the necessary tables and indexes so that the load may proceed.  After you've done that (and created the necessary tables and indexes), you may load up the postgres dump like so:
+
+`psql -d isb_1 -f isamples_data_only.sql`
+
 ### Python virtual environment creation
 
 Create a python virtual environment, checkout the source, and run poetry install.

--- a/docs/indexing_integration_test.md
+++ b/docs/indexing_integration_test.md
@@ -41,6 +41,9 @@ Once it's done you should be able to hit solr using the local URL and query the 
 ## Running the unit test
 After the container is up
 `apt-get install emacs` (or your favorite editor in case you need to edit things)
+
 `export INPUT_SOLR_URL="http://localhost:8000/thing/select"`
+
 `pip3 install pytest`
+
 `pytest test_solr_search_results.py -k "test_solr_integration_test"`

--- a/docs/indexing_integration_test.md
+++ b/docs/indexing_integration_test.md
@@ -13,8 +13,10 @@ There's a script in `scripts/indexing_integration_test/manage_things_with_ids.py
 ```
 python manage_things_with_id.py -d "db_url" dump --input_file /tmp/source_ids --output_file /tmp/dumped_things
 ```
+You will run the dump against the *full database of iSamples content*.
+
 ## Loading the data
-After you've dumped the data, you may load it back up using the `load` command in the same script:
+After you've dumped the data, you will load it up into *the empty iSamples database* using the `load` command in the same script:
 
 ```
 python manage_things_with_id.py -d "db_url" load --input_file /tmp/dumped_things


### PR DESCRIPTION
Hi @hyunssong I went over my notes and I think this should hopefully clarify things.  I've placed a dump of iSamples Central in `/var/local/data/` on mars.cyverse.org.  You can use this to load up your local database for dumping purposes.

Please try this workflow out and add comments about things that are confusing.