### PR TITLE
Rename highest resolution h3 value to h3_15

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -670,7 +670,7 @@ class CoreSolrImporter:
                     #  computed the h3 just grab it off the Thing
                     # Step 3 in this sequence of events is both slow and API rate-limited by Cesium, so we take great
                     # pain to ensure that we're only querying the absolute minimum
-                    core_record["producedBy_samplingSite_location_h3"] = thing.h3
+                    core_record["producedBy_samplingSite_location_h3_15"] = thing.h3
                     core_record["producedBy_samplingSite_location_cesium_height"] = h3_to_height.get(thing.h3)
                     core_records.append(core_record)
                 for r in core_records:

--- a/scripts/migrations/solr/add_h3_different_resolutions.py
+++ b/scripts/migrations/solr/add_h3_different_resolutions.py
@@ -25,7 +25,7 @@ def add_h3_values(solr_url: str):
     current_mutated_batch = []
     rsession = requests.session()
     iterator = ISBCoreSolrRecordIterator(
-        rsession, "-(_nest_path_:*)", batch_size, 0, "id asc"
+        rsession, "-(_nest_path_:*) AND producedBy_samplingSite_location_latitude:*", batch_size, 0, "id asc"
     )
     for record in iterator:
         mutated_record = mutate_record(record)
@@ -49,11 +49,14 @@ def save_mutated_batch(current_mutated_batch, rsession, solr_url):
 
 
 def mutate_record(record: dict) -> Optional[dict]:
-    if record.get("producedBy_samplingSite_location_h3") is None or record.get("producedBy_samplingSite_location_h3_0") is not None:
+    if record.get("producedBy_samplingSite_location_h3_0") is not None:
         return None
     # Do whatever work is required to mutate the record to update things…
     record_copy = record.copy()
-    for index in range(0, 15):
+    # Remove old problematic fields
+    record.pop("producedBy_samplingSite_location_h3")
+    record_copy.pop("producedBy_samplingSite_location_cesium_height")
+    for index in range(0, 16):
         h3_at_resolution = geo_to_h3(
             record.get("producedBy_samplingSite_location_latitude"),
             record.get("producedBy_samplingSite_location_longitude"),

--- a/solr_schema_init/create_isb_core_schema.py
+++ b/solr_schema_init/create_isb_core_schema.py
@@ -240,7 +240,6 @@ addFieldType({
 })
 createField("producedBy_resultTimeRange", "date_range", True, True, None)
 
-createField("producedBy_samplingSite_location_h3", "string", True, True, None)
 createField("producedBy_samplingSite_location_h3_0", "string", False, False, None, False, True)
 createField("producedBy_samplingSite_location_h3_1", "string", False, False, None, False, True)
 createField("producedBy_samplingSite_location_h3_2", "string", False, False, None, False, True)
@@ -256,6 +255,7 @@ createField("producedBy_samplingSite_location_h3_11", "string", False, False, No
 createField("producedBy_samplingSite_location_h3_12", "string", False, False, None, False, True)
 createField("producedBy_samplingSite_location_h3_13", "string", False, False, None, False, True)
 createField("producedBy_samplingSite_location_h3_14", "string", False, False, None, False, True)
+createField("producedBy_samplingSite_location_h3_15", "string", False, False, None, False, True)
 createField("producedBy_samplingSite_location_cesium_height", "pfloat", True, True, None)
 # Nested document support
 # Note that the solr docs indicate we need these fields, but they already existed in our schema, keeping here for


### PR DESCRIPTION
Per discussion at this morning's standup -- rename the `h3` field to `h3_15` since that is what it actually is, and we can't save the old `h3` value on the corrupted solr indexes.