### PR TITLE
Improve indexing error messages in expected cases

### DIFF
--- a/isamples_metadata/metadata_exceptions.py
+++ b/isamples_metadata/metadata_exceptions.py
@@ -1,0 +1,11 @@
+class MetadataException(Exception):
+    """Exception superclass for all known iSamples exceptions"""
+
+
+class TestRecordException(MetadataException):
+    """Exception subclass used to indicate a record is excluded from indexing due to it being a test record"""
+
+
+class SESARSampleTypeException(MetadataException):
+    """Exception subclass used to indicate a record is excluded from indexing due to it being a SESAR record that
+    doesn't represent a valid sample in the iSamples universe"""

--- a/isamples_metadata/taxonomy/metadata_models.py
+++ b/isamples_metadata/taxonomy/metadata_models.py
@@ -5,6 +5,7 @@ import os
 from typing import Tuple, Optional, List
 
 from isamples_metadata.Transformer import Transformer
+from isamples_metadata.metadata_exceptions import TestRecordException, SESARSampleTypeException
 from isb_web import config
 
 from isamples_metadata.taxonomy.Model import Model
@@ -135,10 +136,10 @@ class SESARMaterialPredictor:
         if field_to_value["igsnPrefix"] != "":
             for test_igsn in SESARClassifierInput.SESAR_test_igsn:
                 if test_igsn in field_to_value["igsnPrefix"]:
-                    return True
+                    raise TestRecordException("Record excluded from indexing due to a known test igsnPrefix")
         if field_to_value["sampleType"] == "Hole" or \
                 field_to_value["sampleType"] == "Site":
-            return True
+            raise SESARSampleTypeException("Record excluded from indexing due to it being a known ignored sampleType")
         return False
 
     def classify_by_sample_type(self, field_to_value: dict) -> Optional[str]:

--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -8,6 +8,8 @@ import json
 import typing
 
 import igsn_lib.time
+
+from isamples_metadata.metadata_exceptions import MetadataException
 from isb_lib.models.thing import Thing
 from isamples_metadata.Transformer import Transformer
 import dateparser
@@ -653,6 +655,9 @@ class CoreSolrImporter:
             for thing in self._thing_iterator.yieldRecordsByPage():
                 try:
                     core_records_from_thing = core_record_function(thing)
+                except MetadataException as e:
+                    getLogger().info(f"Excluding record {thing.id} from index due to known exclusion: \"{e}\".")
+                    continue
                 except Exception as e:
                     getLogger().error("Failed trying to run transformer, skipping record %s exception %s",
                                       thing.resolved_content, e)


### PR DESCRIPTION
While running the indexer on hyde, I was seeing a lot of errors.  It turns out that these were expected errors.  Change the error handling a bit so that we aren't confused by these expected cases.