### PR TITLE
Fetch raw columns for solr import

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -6,7 +6,7 @@ import datetime
 import hashlib
 import json
 import typing
-
+import time
 import igsn_lib.time
 
 from isamples_metadata import SESARTransformer
@@ -593,6 +593,7 @@ class ThingRecordIterator:
     def yieldRecordsByPage(self):
         while True:
             n = 0
+            ns = time.time_ns()
             things = sqlmodel_database.paged_things_with_ids(
                 self._session,
                 self._authority_id,
@@ -603,6 +604,8 @@ class ThingRecordIterator:
                 self._id,
                 self._only_resolved_content
             )
+            new_ns = time.time_ns()
+            print(f"Took {(new_ns - ns) / 1000000} ms to fetch resolved content")
             max_id_in_page = 0
             for rec in things:
                 n += 1

--- a/isb_lib/sesar_adapter.py
+++ b/isb_lib/sesar_adapter.py
@@ -174,13 +174,13 @@ def reparseThing(thing: Thing) -> Thing:
     return thing
 
 
-def reparseAsCoreRecord(thing: Thing) -> typing.List[typing.Dict]:
-    _validateResolvedContent(thing)
-    if thing.resolved_content is not None:
-        transformer = isamples_metadata.SESARTransformer.SESARTransformer(thing.resolved_content)
-        return [isb_lib.core.coreRecordAsSolrDoc(transformer)]
-    else:
-        return []
+def reparseAsCoreRecord(resolved_content: dict) -> typing.List[typing.Dict]:
+    # _validateResolvedContent(thing)
+    # if thing.resolved_content is not None:
+    transformer = isamples_metadata.SESARTransformer.SESARTransformer(resolved_content)
+    return [isb_lib.core.coreRecordAsSolrDoc(transformer)]
+    # else:
+    #     return []
 
 
 def _sesar_last_updated(dict: typing.Dict) -> typing.Optional[datetime.datetime]:

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -173,8 +173,13 @@ def _base_thing_select(
     limit: int = 100,
     offset: int = 0,
     min_id: int = 0,
+    only_resolved_content: bool = False
 ) -> SelectOfScalar[Thing]:
-    thing_select = select(Thing).filter(Thing.resolved_status == status)
+    if only_resolved_content:
+        thing_select = select(Thing.primary_key, Thing.resolved_content)
+    else:
+        thing_select = select(Thing)
+    thing_select = thing_select.filter(Thing.resolved_status == status)
     if authority is not None:
         thing_select = thing_select.filter(Thing.authority_id == authority)
     if offset > 0:
@@ -194,8 +199,9 @@ def paged_things_with_ids(
     offset: int = 0,
     min_time_created: Optional[datetime.datetime] = None,
     min_id: int = 0,
-) -> List[Thing]:
-    thing_select = _base_thing_select(authority, status, limit, offset, min_id)
+    only_resolved_content: bool = False
+) -> list:
+    thing_select = _base_thing_select(authority, status, limit, offset, min_id, only_resolved_content)
 
     if min_time_created is not None:
         thing_select = thing_select.filter(Thing.tcreated >= min_time_created)

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -2,6 +2,8 @@ import datetime
 import random
 
 import pytest
+from sqlalchemy.engine import Row
+
 from isb_lib.models.namespace import Namespace
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session, SQLModel, create_engine
@@ -126,6 +128,19 @@ def test_paged_things_with_ids(session: Session):
     assert 5 == len(things_with_tcreated)
     all_things = paged_things_with_ids(session, authority, 200, 100, 0, None, 0)
     assert 15 == len(all_things)
+
+
+def test_paged_things_with_ids_only_resolved_content(session: Session):
+    authority = "test_authority"
+    old_tcreated = datetime.datetime(1978, month=11, day=22)
+    _add_some_things(session, 10, authority, old_tcreated)
+    things_resolved_content = paged_things_with_ids(session, authority, 200, 10, 0, None, 0, True)
+    # This should be everything, check we get 10 back
+    assert 10 == len(things_resolved_content)
+    first_row = things_resolved_content[0]
+    assert type(first_row) is Row
+    assert type(first_row[0]) is int
+    assert type(first_row[1]) is dict
 
 
 def test_things_for_sitemap(session: Session):


### PR DESCRIPTION
Incomplete experiment to see if only fetching individual columns could speed up the solr import slowness we're seeing.  Results on my local machine indicate there are minimal gains to be had, if any.