### PR TITLE
Turn on faulthandler so we can always know what's happening during long-running imports

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -6,6 +6,8 @@ import datetime
 import hashlib
 import json
 import typing
+import faulthandler
+from signal import SIGINT
 
 import igsn_lib.time
 
@@ -647,6 +649,8 @@ class CoreSolrImporter:
             self._db_batch_size,
             self._solr_batch_size,
         )
+        faulthandler.enable()
+        faulthandler.register(SIGINT)
         allkeys = set()
         rsession = requests.session()
         h3_to_height = sqlmodel_database.h3_to_height(self._db_session)


### PR DESCRIPTION
While bringing up the index on AWS, I was often confused about why things were taking so long during solr imports.  Turns out there is a built-in Python module to handle this situation.

Simply do Ctrl-C while the import is running and we now get nice stack traces like this:

```
^CCurrent thread 0x00007fb804852740 (most recent call first):
  File "/usr/local/lib/python3.9/site-packages/dateparser/utils/__init__.py", line 103 in apply_dateparser_timezone
  File "/usr/local/lib/python3.9/site-packages/dateparser/utils/__init__.py", line 115 in apply_timezone
  File "/usr/local/lib/python3.9/site-packages/dateparser/freshness_date_parser.py", line 91 in parse
  File "/usr/local/lib/python3.9/site-packages/dateparser/freshness_date_parser.py", line 156 in get_date_data
  File "/usr/local/lib/python3.9/site-packages/dateparser/date.py", line 196 in _try_freshness_parser
  File "/usr/local/lib/python3.9/site-packages/dateparser/date.py", line 182 in _parse
  File "/usr/local/lib/python3.9/site-packages/dateparser/date.py", line 178 in parse
  File "/usr/local/lib/python3.9/site-packages/dateparser/date.py", line 428 in get_date_data
  File "/usr/local/lib/python3.9/site-packages/dateparser/__init__.py", line 61 in parse
  File "/usr/local/lib/python3.9/site-packages/dateparser/conf.py", line 92 in wrapper
  File "/app/isb_lib/core.py", line 305 in parsed_date
  File "/app/isb_lib/core.py", line 256 in handle_produced_by_fields
  File "/app/isb_lib/core.py", line 185 in _coreRecordAsSolrDoc
  File "/app/isb_lib/core.py", line 209 in coreRecordAsSolrDoc
  File "/app/isb_lib/sesar_adapter.py", line 181 in reparseAsCoreRecord
  File "/app/isb_lib/core.py", line 661 in run_solr_import
  File "/app/scripts/sesar_things.py", line 352 in populateIsbCoreSolr
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 21 in new_func
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 610 in invoke
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1066 in invoke
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1259 in invoke
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 782 in main
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 829 in __call__
  File "/app/scripts/sesar_things.py", line 357 in <module>
```