### PR TITLE
Switch to DateDataParser for performance reasons

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -14,7 +14,7 @@ import igsn_lib.time
 from isamples_metadata.metadata_exceptions import MetadataException
 from isb_lib.models.thing import Thing
 from isamples_metadata.Transformer import Transformer
-import dateparser
+from dateparser.date import DateDataParser
 import re
 import requests
 import shapely.wkt
@@ -37,6 +37,7 @@ DATEPARSER_SETTINGS = {
     "TIMEZONE": "UTC",
     "RETURN_AS_TIMEZONE_AWARE": True,
 }
+ddp = DateDataParser(languages=["en"], settings=DATEPARSER_SETTINGS)
 
 SOLR_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 ELEVATION_PATTERN = re.compile(r"\s*(-?\d+\.?\d*)\s*m?", re.IGNORECASE)
@@ -302,10 +303,11 @@ def handle_related_resources(coreMetadata: typing.Dict, doc: typing.Dict):
 
 def parsed_date(raw_date_str):
     # TODO: https://github.com/isamplesorg/isamples_inabox/issues/24
-    date_time = dateparser.parse(
-        raw_date_str, date_formats=RECOGNIZED_DATE_FORMATS, settings=DATEPARSER_SETTINGS
-    )
-    return date_time
+    date_data = ddp.get_date_data(raw_date_str, date_formats=RECOGNIZED_DATE_FORMATS)
+    if date_data is not None:
+        return date_data.date_obj
+    else:
+        return None
 
 
 def parsed_datetime_from_isamples_format(raw_date_str) -> datetime.datetime:


### PR DESCRIPTION
Upon examining the indexing performance, it seemed like there were many times when we were in the dateparser stacktrace.  Dateparser is known to be a bit slow, so I looked at their documentation, and they suggested DateDataParser as an alternative: https://dateparser.readthedocs.io/en/latest/usage.html

I wrote a simple test on my Mac, and for 5000 dates, `dateparser.parse` was ~2200ms and `DateDataParser` was ~1600ms.  Not super fast either way, but if we extrapolate that out to 6000000 calls, it could easily save a few minutes.  We had unit tests in place for the date calls, and they all pass unmodified with the new api calls in place.