### PR TITLE
H3 values were missing when running the indexer

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -13,7 +13,7 @@ import igsn_lib.time
 
 from isamples_metadata.metadata_exceptions import MetadataException
 from isb_lib.models.thing import Thing
-from isamples_metadata.Transformer import Transformer
+from isamples_metadata.Transformer import Transformer, geo_to_h3
 import dateparser
 from dateparser.date import DateDataParser
 import re
@@ -240,6 +240,14 @@ def lat_lon_to_solr(coreMetadata: typing.Dict, latitude: typing.SupportsFloat, l
     coreMetadata.update(shapely_to_solr(shapely.geometry.Point(longitude, latitude)))
     coreMetadata["producedBy_samplingSite_location_latitude"] = latitude
     coreMetadata["producedBy_samplingSite_location_longitude"] = longitude
+    for index in range(0, 16):
+        h3_at_resolution = geo_to_h3(
+            latitude,
+            longitude,
+            index,
+        )
+        field_name = f"producedBy_samplingSite_location_h3_{index}"
+        coreMetadata[field_name] = h3_at_resolution
 
 
 def handle_produced_by_fields(coreMetadata: typing.Dict, doc: typing.Dict):  # noqa: C901 -- need to examine computational complexity

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -70,6 +70,8 @@ def test_coreRecordAsSolrDoc():
     """
     solr_dict = _try_to_add_solr_doc(core_doc_str)
     assert "producedBy_samplingSite_location_ll" in solr_dict
+    assert "producedBy_samplingSite_location_h3_0" in solr_dict
+    assert "producedBy_samplingSite_location_h3_15" in solr_dict
 
 
 def test_coreRecordAsSolrDoc2():


### PR DESCRIPTION
They were present when running the transformer, but didn't make it over to the solr doc.  As @datadavev noted, this caused the values to not be present in the index. Currently running a job that will add them to the existing records in the index, and this fix will ensure they exist moving forward.