### PR TITLE
Don't leak database connections!

### DIFF
--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -107,7 +107,9 @@ app.include_router(metrics.router)
 @app.on_event("startup")
 def on_startup():
     dao.connect_sqlmodel(isb_web.config.Settings().database_url)
-    orcid_ids = sqlmodel_database.all_orcid_ids(dao.get_session())
+    session = dao.get_session()
+    orcid_ids = sqlmodel_database.all_orcid_ids(session)
+    session.close()
     # Superusers are allowed to mint identifiers as well, so make sure they're in the list.
     orcid_ids.extend(isb_web.config.Settings().orcid_superusers)
     # The main handler's startup is the guaranteed spot where we know we have a db connection.


### PR DESCRIPTION
On investigation of the monitoring problem I saw this error:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/14/3o7r)
```

Basically, we were leaking database connections in the metrics handler.  The fix for this is to properly use the session generator that manages the context and automatically closes it after the work is done.

Fixed one other place where this was occurring as well.