### PR TITLE
Move the audience to config instead of hardcoding to localhost

### DIFF
--- a/isb_web/config.py
+++ b/isb_web/config.py
@@ -88,6 +88,8 @@ class Settings(BaseSettings):
     hypothesis_jwt_client_id: str = ""
     # The client secret to use when signing Hypothesis JWT
     hypothesis_jwt_client_secret: str = ""
+    # The audience to use when signing Hypothesis JWT
+    hypothesis_audience: str = ""
 
     # List of domain names that will be accepted as valid CORS origins.  '*' is unacceptable because we need to
     # include credentials in JavaScript requests, and '*' is disallowed when you configure things like this.

--- a/isb_web/manage.py
+++ b/isb_web/manage.py
@@ -378,11 +378,12 @@ def hypothesis_jwt(request: starlette.requests.Request, session: Session = Depen
         client_authority = config.Settings().hypothesis_authority
         client_id = config.Settings().hypothesis_jwt_client_id
         client_secret = config.Settings().hypothesis_jwt_client_secret
+        client_audience = config.Settings().hypothesis_audience
         now = datetime.datetime.utcnow()
         userid = f"acct:{orcid_id}@{client_authority}"
         logging.debug(f"Going to sign userid {userid} with client_id {client_id} and client secret {client_secret}")
         payload = {
-            "aud": "localhost",
+            "aud": client_audience,
             "iss": client_id,
             "sub": userid,
             "nbf": now,


### PR DESCRIPTION
This was incorrectly done when I was first trying to figure it all out.  For the production hypothesis server, the audience will be `hypothes.is`.

See also https://github.com/isamplesorg/isamples_docker/pull/50 for the actual change to introduce this key.