### PR TITLE
Oc api update from develop

### DIFF
--- a/isamples_metadata/OpenContextTransformer.py
+++ b/isamples_metadata/OpenContextTransformer.py
@@ -169,27 +169,25 @@ class OpenContextTransformer(Transformer):
             "late bce/ce", self.source_record, description_pieces
         )
         self._transform_key_to_label("updated", self.source_record, description_pieces)
-        for consists_of_dict in self.source_record.get("Consists of", []):
-            self._transform_key_to_label(
-                "label", consists_of_dict, description_pieces, "Consists of"
+        for consists_of_str in self.source_record.get("Consists of", []):
+            self._transform_key_to_label_str(
+                self._get_oc_str_or_dict_item_label(consists_of_str), description_pieces, "Consists of"
             )
-        for has_type_dict in self.source_record.get("Has type", []):
-            self._transform_key_to_label(
-                "label", has_type_dict, description_pieces, "Has type"
+        for has_type_str in self.source_record.get("Has type", []):
+                self._transform_key_to_label_str(
+                self._get_oc_str_or_dict_item_label(has_type_str), description_pieces, "Has type"
             )
-        for has_anatomical_dict in self.source_record.get(
+        for has_anatomical_str in self.source_record.get(
             "Has anatomical identification", []
         ):
-            self._transform_key_to_label(
-                "label",
-                has_anatomical_dict,
+            self._transform_key_to_label_str(
+                self._get_oc_str_or_dict_item_label(has_anatomical_str),
                 description_pieces,
                 "Has anatomical identification",
             )
-        for temporal_coverage_dict in self.source_record.get("Temporal Coverage", []):
-            self._transform_key_to_label(
-                "label",
-                temporal_coverage_dict,
+        for temporal_coverage_str in self.source_record.get("Temporal Coverage", []):
+            self._transform_key_to_label_str(
+                self._get_oc_str_or_dict_item_label(temporal_coverage_str),
                 description_pieces,
                 "Temporal coverage",
             )

--- a/isamples_metadata/OpenContextTransformer.py
+++ b/isamples_metadata/OpenContextTransformer.py
@@ -174,7 +174,7 @@ class OpenContextTransformer(Transformer):
                 self._get_oc_str_or_dict_item_label(consists_of_str), description_pieces, "Consists of"
             )
         for has_type_str in self.source_record.get("Has type", []):
-                self._transform_key_to_label_str(
+            self._transform_key_to_label_str(
                 self._get_oc_str_or_dict_item_label(has_type_str), description_pieces, "Has type"
             )
         for has_anatomical_str in self.source_record.get(

--- a/isamples_metadata/OpenContextTransformer.py
+++ b/isamples_metadata/OpenContextTransformer.py
@@ -347,7 +347,7 @@ class OpenContextTransformer(Transformer):
     def informal_classification(self) -> typing.List[str]:
         classifications = []
         for consists_of_dict in self.source_record.get("Has taxonomic identifier", []):
-            classifications.append(consists_of_dict.get("label"))
+            classifications.append(self._get_oc_str_or_dict_item_label(consists_of_dict))
         return classifications
 
     def last_updated_time(self) -> Optional[str]:

--- a/isamples_metadata/OpenContextTransformer.py
+++ b/isamples_metadata/OpenContextTransformer.py
@@ -318,11 +318,11 @@ class OpenContextTransformer(Transformer):
         creators = self.source_record.get("Creator")
         if creators is not None:
             for creator in creators:
-                responsibilities.append(f"creator: {creator.get('label')}")
+                responsibilities.append(f"creator: {creator}")
         contributors = self.source_record.get("Contributor")
         if contributors is not None:
             for contributor in contributors:
-                responsibilities.append(f"collector: {contributor.get('label')}")
+                responsibilities.append(f"collector: {contributor}")
         return responsibilities
 
     def produced_by_result_time(self) -> str:

--- a/isamples_metadata/Transformer.py
+++ b/isamples_metadata/Transformer.py
@@ -44,6 +44,15 @@ class Transformer(ABC):
             dest_list.append(f"{label}: {value}")
 
     @staticmethod
+    def _transform_key_to_label_str(
+        value: str,
+        dest_list: typing.List[str],
+        label: Optional[str] = None,
+    ):
+        if value is not None and len(str(value)) > 0:
+            dest_list.append(f"{label}: {value}")
+
+    @staticmethod
     def _formatted_date(
         year: Optional[str], month: Optional[str], day: Optional[str]
     ) -> str:

--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -10,8 +10,8 @@ import dateparser
 from isamples_metadata import OpenContextTransformer
 
 
-HTTP_TIMEOUT = 10.0  # seconds
-OPENCONTEXT_PAGE_SIZE = 250  # number of result records per request "page"
+HTTP_TIMEOUT = 60.0  # seconds
+OPENCONTEXT_PAGE_SIZE = 100       # number of result records per request "page"
 OPENCONTEXT_API = f"https://opencontext.org/query/.json?attributes=ALL-STANDARD-LD&cat=oc-gen-cat-sample-col%7C%7Coc-gen-cat-bio-subj-ecofact%7C%7Coc-gen-cat-object&response=metadata%2Curi-meta&sort=updated--desc&type=subjects&rows={OPENCONTEXT_PAGE_SIZE}"
 MEDIA_JSON = "application/json"
 

--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -11,11 +11,9 @@ from isamples_metadata import OpenContextTransformer
 
 
 HTTP_TIMEOUT = 10.0  # seconds
-OPENCONTEXT_PAGE_SIZE = 250 # number of result records per request "page"
+OPENCONTEXT_PAGE_SIZE = 250  # number of result records per request "page"
 OPENCONTEXT_API = f"https://opencontext.org/query/.json?attributes=ALL-STANDARD-LD&cat=oc-gen-cat-sample-col%7C%7Coc-gen-cat-bio-subj-ecofact%7C%7Coc-gen-cat-object&response=metadata%2Curi-meta&sort=updated--desc&type=subjects&rows={OPENCONTEXT_PAGE_SIZE}"
 MEDIA_JSON = "application/json"
-
-
 
 
 def get_logger():

--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -9,9 +9,13 @@ import typing
 import dateparser
 from isamples_metadata import OpenContextTransformer
 
+
 HTTP_TIMEOUT = 10.0  # seconds
-OPENCONTEXT_API = "https://opencontext.org/subjects-search/.json?add-attribute-uris=1&attributes=obo-foodon-00001303%2Coc-zoo-has-anat-id%2Ccidoc-crm-p2-has-type%2Ccidoc-crm-p45-consists-of%2Ccidoc-crm-p49i-is-former-or-current-keeper-of%2Ccidoc-crm-p55-has-current-location%2Cdc-terms-temporal%2Cdc-terms-creator%2Cdc-terms-contributor&prop=oc-gen-cat-sample-col%7C%7Coc-gen-cat-bio-subj-ecofact%7C%7Coc-gen-cat-object&response=metadata%2Curi-meta&sort=updated--desc"
+OPENCONTEXT_PAGE_SIZE = 250 # number of result records per request "page"
+OPENCONTEXT_API = f"https://opencontext.org/query/.json?attributes=ALL-STANDARD-LD&cat=oc-gen-cat-sample-col%7C%7Coc-gen-cat-bio-subj-ecofact%7C%7Coc-gen-cat-object&response=metadata%2Curi-meta&sort=updated--desc&type=subjects&rows={OPENCONTEXT_PAGE_SIZE}"
 MEDIA_JSON = "application/json"
+
+
 
 
 def get_logger():
@@ -68,7 +72,7 @@ class OpenContextRecordIterator(isb_lib.core.IdentifierIterator):
         max_entries: int = -1,
         date_start: Optional[datetime.datetime] = None,
         date_end: Optional[datetime.datetime] = None,
-        page_size: int = 100,
+        page_size: int = OPENCONTEXT_PAGE_SIZE,
     ):
         super().__init__(
             offset=offset,

--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -133,6 +133,7 @@ class OpenContextRecordIterator(isb_lib.core.IdentifierIterator):
                 yield record
                 num_records += 1
 
+            self.url = next_url
             if (
                 len(data.get("oc-api:has-results", {})) < _page_size
                 or self.url is None
@@ -141,8 +142,6 @@ class OpenContextRecordIterator(isb_lib.core.IdentifierIterator):
                 or self._past_date_start
             ):
                 more_work = False
-            if more_work:
-                self.url = next_url
 
     def loadEntries(self):
         self._cpage = []

--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -137,6 +137,7 @@ class OpenContextRecordIterator(isb_lib.core.IdentifierIterator):
                 len(data.get("oc-api:has-results", {})) < _page_size
                 or self.url is None
                 or 0 < self._max_entries <= num_records
+                or num_records == self._page_size
                 or self._past_date_start
             ):
                 more_work = False

--- a/scripts/opencontext_things.py
+++ b/scripts/opencontext_things.py
@@ -10,6 +10,7 @@ import sqlalchemy.orm
 import sqlalchemy.exc
 
 from isb_lib import opencontext_adapter
+from isb_lib.opencontext_adapter import OPENCONTEXT_PAGE_SIZE
 from isb_web import sqlmodel_database
 from isb_web.sqlmodel_database import SQLModelDAO, save_thing
 
@@ -32,7 +33,7 @@ def wrap_load_thing(thing_dict, tc):
 async def _load_open_context_entries(session, max_count, start_from):
     L = get_logger()
     records = isb_lib.opencontext_adapter.OpenContextRecordIterator(
-        max_entries=max_count, date_start=start_from, page_size=200
+        max_entries=max_count, date_start=start_from, page_size=OPENCONTEXT_PAGE_SIZE
     )
 
     num_ids = 0


### PR DESCRIPTION
This update is in response to issue: https://github.com/isamplesorg/isamples_inabox/issues/295

This change includes:
(1) Updated the Open Context API URL following updates to Open Context's API
(2) I added a global `OPENCONTEXT_PAGE_SIZE` set to 250 to pull more records from Open Context per request
(3) I made a few modifications to the lists configuring mappings between Open Context "item categories" and iSamples materials and categories
(4) I added a function / method (`_get_oc_str_or_dict_item_label`) for reading either a string value or the 'label' key from a dictionary to get the value for certain attributes. I'm not sure how this should work with the existing Transformer `_transform_key_to_label`  method
