### PR TITLE
Handle OpenContext records missing identifiers without breaking the import

### DIFF
--- a/isamples_metadata/OpenContextTransformer.py
+++ b/isamples_metadata/OpenContextTransformer.py
@@ -8,6 +8,7 @@ from isamples_metadata.Transformer import (
     StringEqualityCategoryMapper,
     AbstractCategoryMapper,
 )
+from isamples_metadata.metadata_exceptions import MissingIdentifierException
 from isamples_metadata.taxonomy.metadata_model_client import MODEL_SERVER_CLIENT, PredictionResult
 
 
@@ -148,7 +149,10 @@ class OpenContextTransformer(Transformer):
         self._specimen_prediction_results: typing.Optional[list] = None
 
     def _citation_uri(self) -> str:
-        return self.source_record.get("citation uri") or ""
+        citation_uri = self.source_record.get("citation uri")
+        if citation_uri is None:
+            raise MissingIdentifierException("OpenContext record is missing a citation uri")
+        return citation_uri
 
     def id_string(self) -> str:
         citation_uri = self._citation_uri()

--- a/isamples_metadata/metadata_exceptions.py
+++ b/isamples_metadata/metadata_exceptions.py
@@ -9,3 +9,7 @@ class TestRecordException(MetadataException):
 class SESARSampleTypeException(MetadataException):
     """Exception subclass used to indicate a record is excluded from indexing due to it being a SESAR record that
     doesn't represent a valid sample in the iSamples universe"""
+
+
+class MissingIdentifierException(MetadataException):
+    """Exception subclass used to indicate a record is excluded from indexing due to it lacking an identifier"""


### PR DESCRIPTION
Encountered a number of records missing identifiers, which cause our Solr importer to fail.  Handle these cases gracefully and exclude them from indexing.