### PR TITLE
Extract bulk inserts/updates into a reusable object

### DIFF
--- a/isb_lib/opencontext_adapter.py
+++ b/isb_lib/opencontext_adapter.py
@@ -215,9 +215,7 @@ def load_thing(
     """
     L = get_logger()
     id = identifier_from_thing_dict(thing_dict)
-    updated_time = thing_dict.get("updated")
-    if updated_time is not None:
-        t_created = dateparser.parse(updated_time)
+    t_created = t_created_from_thing_dict(thing_dict)
     L.info("loadThing: %s", id)
     item = OpenContextItem(id, thing_dict)
     # TODO, unlike the other collections, we are fetching these via a pre-paginated API, so we can't put anything in the
@@ -225,6 +223,13 @@ def load_thing(
     # nothing to do here, but it's a difference between collections.
     thing = item.as_thing(t_created, 200, url, t_resolved, None)
     return thing
+
+
+def t_created_from_thing_dict(thing_dict):
+    updated_time = thing_dict.get("updated")
+    if updated_time is not None:
+        t_created = dateparser.parse(updated_time)
+    return t_created
 
 
 def update_thing(thing: isb_lib.models.thing.Thing, updated_record: typing.Dict, t_resolved: datetime.datetime, url: str):

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -27,7 +27,7 @@ DRAFT_RESOLVED_STATUS = -1
 
 
 class DatabaseBulkUpdater:
-    def __init__(self, db_session: Session, authority_id: str, batch_size: int, resolved_media_type: str, primary_keys_by_id: dict):
+    def __init__(self, db_session: Session, authority_id: str, batch_size: int, resolved_media_type: str, primary_keys_by_id: Optional[dict]):
         self.db_session = db_session
         self.authority_id = authority_id
         self.batch_size = batch_size
@@ -36,8 +36,11 @@ class DatabaseBulkUpdater:
         self.current_existing_things_batch = []
         self.num_inserts = 0
         self.num_updates = 0
-        self.primary_keys_by_id = primary_keys_by_id
         self.unique_ids = set()
+        if primary_keys_by_id is not None:
+            self.primary_keys_by_id = primary_keys_by_id
+        else:
+            self.primary_keys_by_id = {}
 
     def add_thing(self, resolved_content: dict, thing_id: str, resolved_url: str, resolved_status: int, h3: str, t_created: Optional[datetime.datetime] = None):
         tstamp = datetime.datetime.now()

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -1,5 +1,6 @@
 import datetime
 import typing
+import json
 
 import igsn_lib.time
 import sqlalchemy
@@ -23,6 +24,71 @@ from isb_web.schemas import ThingPage
 DRAFT_RESOLVED_URL = "DRAFT"
 DRAFT_AUTHORITY_ID = "DRAFT"
 DRAFT_RESOLVED_STATUS = -1
+
+
+class DatabaseBulkUpdater:
+    def __init__(self, db_session: Session, authority_id: str, batch_size: int, resolved_media_type: str, primary_keys_by_id: dict):
+        self.db_session = db_session
+        self.authority_id = authority_id
+        self.batch_size = batch_size
+        self.resolved_media_type = resolved_media_type
+        self.current_new_things_batch = []
+        self.current_existing_things_batch = []
+        self.num_inserts = 0
+        self.num_updates = 0
+        self.primary_keys_by_id = primary_keys_by_id
+        self.unique_ids = set()
+
+    def add_thing(self, resolved_content: dict, thing_id: str, resolved_url: str, resolved_status: int, h3: str, t_created: Optional[datetime.datetime] = None):
+        tstamp = datetime.datetime.now()
+        if t_created is None:
+            t_created = tstamp
+        thing_dict = {
+            "resolved_content": resolved_content,
+            "id": thing_id,
+            "tstamp": tstamp,
+            "tcreated": t_created,
+            "item_type": "sample",
+            "authority_id": self.authority_id,
+            "resolved_url": resolved_url,
+            "resolved_status": resolved_status,
+            "tresolved": tstamp,
+            "resolve_elapsed": 0,
+            "resolved_media_type": self.resolved_media_type,
+            "identifiers": json.dumps([thing_id]),
+            "h3": h3
+        }
+        if thing_id in self.primary_keys_by_id:
+            thing_dict["primary_key"] = self.primary_keys_by_id[thing_id]
+        else:
+            self.current_new_things_batch.append(thing_dict)
+        self.unique_ids.add(thing_id)
+        if (len(self.current_new_things_batch) + len(self.current_existing_things_batch)) == self.batch_size:
+            self._save_to_db()
+
+    def finish(self):
+        print("About to finish import…")
+        self._save_to_db()
+        print(f"Finished at {datetime.datetime.now()}.")
+
+    def _save_to_db(self):
+        self.num_inserts += len(self.current_new_things_batch)
+        self.num_updates += len(self.current_existing_things_batch)
+        print(f"\n\nInserting into the database because we've hit the batch size of {self.batch_size}")
+        if len(self.current_new_things_batch) > 0:
+            self.db_session.bulk_insert_mappings(
+                mapper=Thing,
+                mappings=self.current_new_things_batch,
+                return_defaults=False,
+            )
+        if len(self.current_existing_things_batch) > 0:
+            self.db_session.bulk_update_mappings(
+                mapper=Thing, mappings=self.current_existing_things_batch
+            )
+        self.db_session.commit()
+        print(f"\n\nSave complete.  Have inserted {self.num_inserts} rows, updated {self.num_updates} rows, seen {len(self.unique_ids)} unique ids.")
+        self.current_new_things_batch = []
+        self.current_existing_things_batch = []
 
 
 class SQLModelDAO:

--- a/scripts/smithsonian_things.py
+++ b/scripts/smithsonian_things.py
@@ -14,9 +14,9 @@ from isb_web.sqlmodel_database import SQLModelDAO, all_thing_primary_keys, Datab
 BATCH_SIZE = 10000
 num_inserts = 0
 num_updates = 0
-current_existing_things_batch = []
-current_new_things_batch = []
-all_ids = set()
+current_existing_things_batch: list[dict] = []
+current_new_things_batch: list[dict] = []
+all_ids: set[str] = set()
 
 
 def load_smithsonian_entries(db_session, file_path, start_from=None):

--- a/scripts/smithsonian_things.py
+++ b/scripts/smithsonian_things.py
@@ -1,6 +1,3 @@
-import json
-import typing
-
 import click
 import click_config_file
 import isb_lib.core
@@ -11,9 +8,8 @@ import datetime
 
 from isamples_metadata import SmithsonianTransformer
 from isb_lib import smithsonian_adapter
-from isb_lib.models.thing import Thing
 from isb_lib.smithsonian_adapter import SmithsonianItem
-from isb_web.sqlmodel_database import SQLModelDAO, all_thing_primary_keys
+from isb_web.sqlmodel_database import SQLModelDAO, all_thing_primary_keys, DatabaseBulkUpdater
 
 BATCH_SIZE = 10000
 num_inserts = 0
@@ -25,28 +21,34 @@ all_ids = set()
 
 def load_smithsonian_entries(db_session, file_path, start_from=None):
     primary_keys_by_id = all_thing_primary_keys(db_session, smithsonian_adapter.SmithsonianItem.AUTHORITY_ID)
+    bulk_updater = DatabaseBulkUpdater(db_session, smithsonian_adapter.SmithsonianItem.AUTHORITY_ID, BATCH_SIZE, SmithsonianItem.TEXT_CSV, primary_keys_by_id)
     with open(file_path, newline="") as csvfile:
         csvreader = csv.reader(csvfile, delimiter="\t", quoting=csv.QUOTE_NONE)
         num_newer = 0
         column_headers = next(csvreader)
         for i, current_values in enumerate(csvreader):
-            if i > 0 and i % BATCH_SIZE == 0:
-                save_to_db(db_session, i, num_newer)
-            # Otherwise iterate over the keys and make source JSON
             current_record = {}
             newer_than_start_from, thing_id = process_keys(column_headers, current_record, current_values, start_from)
             if newer_than_start_from:
                 num_newer += 1
-                thing_dict = thing_dict_for_db(current_record, file_path, thing_id, primary_keys_by_id)
-                if thing_id in primary_keys_by_id:
-                    current_existing_things_batch.append(thing_dict)
-                else:
-                    current_new_things_batch.append(thing_dict)
-            all_ids.add(thing_id)
-
-        # get the remainder
-        save_to_db(db_session, i, num_newer)
-        print(f"Done.  Num inserts={num_inserts}, num updates={num_updates}, num_unique_ids={len(all_ids)}")
+                h3 = SmithsonianTransformer.geo_to_h3(current_record)
+                try:
+                    year = current_record.get("year")
+                    month = current_record.get("month")
+                    day = current_record.get("day")
+                    if year is not None and month is not None and day is not None:
+                        t_created = datetime.datetime(
+                            year=int(year),
+                            month=int(month),
+                            day=int(day),
+                        )
+                except Exception:
+                    # In many cases, these don't seem to be populated.  There's nothing we can do if they aren't there, so just
+                    # leave it as None.
+                    t_created = None
+                bulk_updater.add_thing(current_record, thing_id, file_path, 200, h3, t_created)
+        bulk_updater.finish()
+        print(f"Num newer={num_newer}\n\n")
 
 
 def process_keys(column_headers, current_record, current_values, start_from):
@@ -70,62 +72,6 @@ def process_keys(column_headers, current_record, current_values, start_from):
                 "Ran into an index error processing input: %s", e
             )
     return newer_than_start_from, thing_id
-
-
-def thing_dict_for_db(resolved_content: typing.Dict, file_path: str, thing_id: str, primary_keys_by_id: typing.Dict):
-    try:
-        year = resolved_content.get("year")
-        month = resolved_content.get("month")
-        day = resolved_content.get("day")
-        if year is not None and month is not None and day is not None:
-            t_created = datetime.datetime(
-                year=int(year),
-                month=int(month),
-                day=int(day),
-            )
-    except Exception:
-        # In many cases, these don't seem to be populated.  There's nothing we can do if they aren't there, so just
-        # leave it as None.
-        t_created = None
-    tstamp = datetime.datetime.now()
-    thing_dict = {
-        "resolved_content": resolved_content,
-        "id": thing_id,
-        "tstamp": tstamp,
-        "tcreated": t_created,
-        "item_type": "sample",
-        "authority_id": SmithsonianItem.AUTHORITY_ID,
-        "resolved_url": f"file://{file_path}",
-        "resolved_status": 200,
-        "tresolved": tstamp,
-        "resolve_elapsed": 0,
-        "resolved_media_type": SmithsonianItem.TEXT_CSV,
-        "identifiers": json.dumps([thing_id]),
-        "h3": SmithsonianTransformer.geo_to_h3(resolved_content)
-    }
-    if thing_id in primary_keys_by_id:
-        thing_dict["primary_key"] = primary_keys_by_id[thing_id]
-
-    return thing_dict
-
-
-def save_to_db(db_session, i, num_newer):
-    global num_inserts, num_updates, current_new_things_batch, current_existing_things_batch
-    num_inserts += len(current_new_things_batch)
-    num_updates += len(current_existing_things_batch)
-    print(f"\n\nNum records={i}")
-    print(f"Num newer={num_newer}\n\n")
-    db_session.bulk_insert_mappings(
-        mapper=Thing,
-        mappings=current_new_things_batch,
-        return_defaults=False,
-    )
-    db_session.bulk_update_mappings(
-        mapper=Thing, mappings=current_existing_things_batch
-    )
-    db_session.commit()
-    current_new_things_batch = []
-    current_existing_things_batch = []
 
 
 @click.group()


### PR DESCRIPTION
Per discussion in standup this morning, we should extract out the database bulk insertion into its own class so we can reuse it for OpenContext and @SeanSCao will be able to reuse the same object when he works on the SESAR iSB instance.  Forthcoming commit will port OpenContext to use the new object.