### PR TITLE
Change the jsonb type to be based on the dialect rather than if we are running in pytest

### DIFF
--- a/isb_lib/models/conditional_jsonb_type.py
+++ b/isb_lib/models/conditional_jsonb_type.py
@@ -1,0 +1,15 @@
+from sqlalchemy import TypeDecorator, JSON
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+class ConditionalJSONB(TypeDecorator):
+    """Type that will use JSONB when connected to postgresql, and JSON otherwise.
+    """
+
+    impl = JSON
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(JSONB())
+        else:
+            return dialect.type_descriptor(JSON())

--- a/isb_lib/models/conditional_jsonb_type.py
+++ b/isb_lib/models/conditional_jsonb_type.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 class ConditionalJSONB(TypeDecorator):
     """Type that will use JSONB when connected to postgresql, and JSON otherwise.
+    Modeled after example at: https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator.load_dialect_impl
     """
 
     impl = JSON

--- a/isb_lib/models/thing.py
+++ b/isb_lib/models/thing.py
@@ -7,6 +7,7 @@ from sqlmodel import Field, SQLModel
 from datetime import datetime
 import sqlalchemy
 
+from isb_lib.models.conditional_jsonb_type import ConditionalJSONB
 from isb_lib.models.string_list_type import StringListType
 
 
@@ -66,8 +67,7 @@ class Thing(SQLModel, table=True):
     resolved_content: Optional[dict] = Field(
         # Use the raw SQLAlchemy column in order to get the proper JSON behavior
         sa_column=sqlalchemy.Column(
-            # if we're running under test, use SQLite type, otherwise prefer postgres JSONB
-            sqlalchemy.JSON if "pytest" in sys.modules else sqlalchemy.dialects.postgresql.JSONB,
+            ConditionalJSONB,
             nullable=True,
             default=None,
             doc="Resolved content, {content_type:, content: }",

--- a/isb_lib/models/thing.py
+++ b/isb_lib/models/thing.py
@@ -1,4 +1,3 @@
-import sys
 import igsn_lib.time
 import json
 from typing import Optional


### PR DESCRIPTION
Fixes https://github.com/isamplesorg/isamples_inabox/issues/315

@datadavev I don't know if you have any suggestions on how to test this more rigorously.  My manual test involved running the unit tests and ensuring we got `JSON`, then running some manual queries against a running iSB instance connected to postgresql and verifying we got `JSONB`.