### PR TITLE
Don't need these installs, and they are failing on github

### DIFF
--- a/.github/workflows/python-integration-test.yaml
+++ b/.github/workflows/python-integration-test.yaml
@@ -39,12 +39,6 @@
      #     key: venv-${{ runner.os }}-#{{ hashFiles('**/poetry.lock') }}
      - name: install pip
        run: poetry run python -m pip install --upgrade pip
-     - name: Hacked install of pybind11
-       run: |
-         poetry run python -m pip install pybind11
-     - name: Hacked install of fasttext
-       run: |
-         poetry run python -m pip install fasttext     
      - name: Install dependencies
        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
        run: poetry install --no-interaction --no-root


### PR DESCRIPTION
On analyzing some failures in our integration tests, running pip attempting to install these were failing.  We don't actually need either of those to run the integration tests, so remove them.