### PR TITLE
Change sitemap generation to happen from database rather than solr

### DIFF
--- a/isb_lib/sitemaps/thing_sitemap.py
+++ b/isb_lib/sitemaps/thing_sitemap.py
@@ -83,7 +83,7 @@ class ThingSitemapIndexIterator:
             self._last_timestamp_str = self._last_url_set_iterator.last_tstamp_str
             self._last_primary_key = self._last_url_set_iterator.last_identifier
         things = things_for_sitemap(
-            self._session, self._authority, self._offset, self._num_things_per_file
+            self._session, self._authority, 200, self._num_things_per_file, self._offset
         )
         if len(things) == 0:
             raise StopIteration

--- a/isb_lib/sitemaps/thing_sitemap.py
+++ b/isb_lib/sitemaps/thing_sitemap.py
@@ -2,12 +2,10 @@ import datetime
 import typing
 from typing import Optional
 
-import requests
 from sqlmodel import Session
 
 from isb_lib.core import datetimeToSolrStr
 from isb_lib.sitemaps import SitemapIndexEntry, UrlSetEntry, ThingUrlSetEntry, ThingSitemapIndexEntry
-from isb_web import isb_solr_query
 from isb_web.sqlmodel_database import things_for_sitemap
 
 MAX_URLS_IN_SITEMAP = 50000

--- a/isb_lib/sitemaps/thing_sitemap.py
+++ b/isb_lib/sitemaps/thing_sitemap.py
@@ -1,10 +1,14 @@
+import datetime
 import typing
 from typing import Optional
 
 import requests
+from sqlmodel import Session
 
+from isb_lib.core import datetimeToSolrStr
 from isb_lib.sitemaps import SitemapIndexEntry, UrlSetEntry, ThingUrlSetEntry, ThingSitemapIndexEntry
 from isb_web import isb_solr_query
+from isb_web.sqlmodel_database import things_for_sitemap
 
 MAX_URLS_IN_SITEMAP = 50000
 
@@ -16,7 +20,7 @@ class ThingUrlSetIterator:
         self,
         sitemap_index: int,
         max_length: int,
-        things: typing.List[typing.Dict[str, str]],
+        things: typing.List[tuple[str, datetime.datetime]],
     ):
         self._things: list = things
         self._thing_index = 0
@@ -34,8 +38,8 @@ class ThingUrlSetIterator:
         if self._thing_index == len(self._things):
             raise StopIteration
         next_thing = self._things[self._thing_index]
-        timestamp_str = next_thing.get("sourceUpdatedTime")
-        next_url_set_entry = ThingUrlSetEntry(next_thing["id"], timestamp_str)
+        timestamp_str = datetimeToSolrStr(next_thing[1])
+        next_url_set_entry = ThingUrlSetEntry(next_thing[0], timestamp_str)
         # Update the necessary state
         self.num_urls += 1
         self._thing_index += 1
@@ -54,6 +58,7 @@ class ThingSitemapIndexIterator:
 
     def __init__(
         self,
+        session: Session,
         authority: Optional[str] = None,
         num_things_per_file: int = MAX_URLS_IN_SITEMAP,
         status: int = 200,
@@ -66,7 +71,7 @@ class ThingSitemapIndexIterator:
         self._status = status
         self._offset = offset
         self._last_url_set_iterator: Optional[ThingUrlSetIterator] = None
-        self._rsession = requests.session()
+        self._session = session
         self.num_url_sets = 0
 
     def __iter__(self):
@@ -77,8 +82,8 @@ class ThingSitemapIndexIterator:
             # Update our last values with the last ones from the previous iterator
             self._last_timestamp_str = self._last_url_set_iterator.last_tstamp_str
             self._last_primary_key = self._last_url_set_iterator.last_identifier
-        things = isb_solr_query.solr_records_for_sitemap(
-            self._rsession, self._authority, self._offset, self._num_things_per_file
+        things = things_for_sitemap(
+            self._session, self._authority, self._offset, self._num_things_per_file
         )
         if len(things) == 0:
             raise StopIteration

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -290,10 +290,12 @@ def things_for_sitemap(
     In order to allow older unchanged records to not be refetched, order by the timestamp to support automatic diffing
     """
     thing_select = _base_thing_select(authority, status, limit, offset, min_id)
+    thing_select = thing_select.with_only_columns(Thing.id, Thing.tstamp)
     if min_tstamp is not None:
         thing_select = thing_select.filter(Thing.tstamp >= min_tstamp)
     thing_select = thing_select.order_by(Thing.tstamp.asc(), Thing.primary_key.asc())
-    return session.exec(thing_select).all()
+    things_result = session.execute(thing_select)
+    return things_result.all()
 
 
 def things_by_authority_count(session: Session) -> list[tuple]:

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -284,7 +284,7 @@ def things_for_sitemap(
     offset: int = 0,
     min_tstamp: Optional[datetime.datetime] = None,
     min_id: int = 0,
-) -> List[Thing]:
+) -> List[tuple[str, datetime]]:
     """Returns a list of Things suitable for generating a sitemap.
 
     In order to allow older unchanged records to not be refetched, order by the timestamp to support automatic diffing

--- a/scripts/generate_things_sitemap.py
+++ b/scripts/generate_things_sitemap.py
@@ -1,6 +1,6 @@
 import click
 
-import isb_web
+import isb_web.config
 import isb_lib.core
 from isb_lib.sitemaps import build_sitemap
 from isb_lib.sitemaps.thing_sitemap import (

--- a/scripts/generate_things_sitemap.py
+++ b/scripts/generate_things_sitemap.py
@@ -6,6 +6,7 @@ from isb_lib.sitemaps import build_sitemap
 from isb_lib.sitemaps.thing_sitemap import (
     ThingSitemapIndexIterator
 )
+from isb_web.sqlmodel_database import SQLModelDAO
 
 
 @click.command()
@@ -25,8 +26,9 @@ from isb_lib.sitemaps.thing_sitemap import (
 )
 @click.pass_context
 def main(ctx, path: str, host: str):
-    isb_lib.core.things_main(ctx, None, isb_web.config.Settings().solr_url, "INFO")
-    build_sitemap(path, host, ThingSitemapIndexIterator())
+    isb_lib.core.things_main(ctx, isb_web.config.Settings().database_url, isb_web.config.Settings().solr_url, "INFO")
+    session = SQLModelDAO(isb_web.config.Settings().database_url).get_session()
+    build_sitemap(path, host, ThingSitemapIndexIterator(session))
 
 
 if __name__ == "__main__":

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -137,26 +137,22 @@ def test_things_for_sitemap(session: Session):
     # should have a list of 20
     assert 20 == len(things)
     for thing in things:
-        assert thing.authority_id == authority
+        assert 2 == len(thing)
+        assert type(thing[0]) is str
+        assert type(thing[1]) is datetime.datetime
     # remember this for later
-    last_tstamp = things[-1].tstamp
-    last_id = things[-1].primary_key
+    last_tstamp = things[-1][1]
+    last_id = things[-1][0]
 
     different_authority = "different"
     _add_some_things(session, 20, different_authority)
 
-    # fetch again, should still get the first ones because they have an older tstamp
-    things_for_sitemap(session, None, 200, 100, 0, None)
-    for thing in things:
-        assert thing.authority_id == authority
-
     # Now fetch with the tstamp and id
-    new_things = things_for_sitemap(session, None, 200, 100, 0, last_tstamp, last_id)
-    # Should get 20, should have the new authority
+    new_things = things_for_sitemap(session, different_authority, 200, 100, 0, last_tstamp, int(last_id))
+    # Should get 21, as the method returns >= timestamp
     assert 20 == len(new_things)
     for new_thing in new_things:
-        assert new_thing.authority_id == different_authority
-
+        assert new_thing[1] >= last_tstamp
 
 def test_thing_iterator(session: Session):
     authority_id = "test"

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -154,6 +154,7 @@ def test_things_for_sitemap(session: Session):
     for new_thing in new_things:
         assert new_thing[1] >= last_tstamp
 
+
 def test_thing_iterator(session: Session):
     authority_id = "test"
     num_things = 10

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ def _add_some_things(
         )
         if tcreated is not None:
             new_thing.tcreated = tcreated
+        new_thing.tstamp = datetime.datetime.now()
         insert_identifiers(new_thing)
         session.add(new_thing)
     session.commit()


### PR DESCRIPTION
Since SESAR doesn't yet have a solr index, build the sitemaps from the db instead of solr.