### PR TITLE
Accept requests for solr select that end with a slash

### DIFF
--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -262,9 +262,7 @@ def set_default_params(params, defs):
     return params
 
 
-# TODO: Don't blindly accept user input!
-@app.get(f"/{THING_URL_PATH}/select", response_model=typing.Any)
-async def get_solr_select(request: fastapi.Request):
+async def _get_solr_select(request: fastapi.Request):
     """Send select request to the Solr isb_core_records collection.
 
     See https://solr.apache.org/guide/8_11/common-query-parameters.html
@@ -297,6 +295,17 @@ async def get_solr_select(request: fastapi.Request):
     # before returning here, hence defeating the purpose of the streaming
     # response.
     return isb_solr_query.solr_query(params)
+
+
+# TODO: Don't blindly accept user input!
+@app.get(f"/{THING_URL_PATH}/select", response_model=typing.Any)
+async def get_solr_select(request: fastapi.Request):
+    return await _get_solr_select(request)
+
+
+@app.get(f"/{THING_URL_PATH}/select/", response_model=typing.Any)
+async def get_solr_select_with_slash(request: fastapi.Request):
+    return await _get_solr_select(request)
 
 
 @app.post(f"/{THING_URL_PATH}/reliquery", response_model=ReliqueryResponse)

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -299,12 +299,10 @@ async def _get_solr_select(request: fastapi.Request):
 
 # TODO: Don't blindly accept user input!
 @app.get(f"/{THING_URL_PATH}/select", response_model=typing.Any)
-async def get_solr_select(request: fastapi.Request):
-    return await _get_solr_select(request)
-
-
 @app.get(f"/{THING_URL_PATH}/select/", response_model=typing.Any)
-async def get_solr_select_with_slash(request: fastapi.Request):
+@app.post(f"/{THING_URL_PATH}/select", response_model=typing.Any)
+@app.post(f"/{THING_URL_PATH}/select/", response_model=typing.Any)
+async def get_solr_select(request: fastapi.Request):
     return await _get_solr_select(request)
 
 

--- a/tests/test_fastapi_apps.py
+++ b/tests/test_fastapi_apps.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fastapi.testclient import TestClient
+from httpx import Response
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
-from starlette.responses import Response
+
 
 from isb_lib.models import thing
 from isb_web.main import get_session, app, manage_app

--- a/tests/test_fastapi_apps.py
+++ b/tests/test_fastapi_apps.py
@@ -1,8 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
+from starlette.responses import Response
+
 from isb_lib.models import thing
 from isb_web.main import get_session, app, manage_app
 
@@ -261,3 +265,32 @@ def test_manage_with_invalid_authorization_header(manage_client: TestClient, ses
     }
     response = manage_client.get("/userinfo", headers=headers, allow_redirects=False)
     assert response.status_code == 400
+
+
+def _assert_on_solr_response(mock_solr_query: MagicMock, response: Response):
+    assert response.status_code == 200
+    assert mock_solr_query.called is True
+
+
+@patch("isb_web.isb_solr_query.solr_query")
+def test_solr_select_get(mock_solr_query: MagicMock, client: TestClient, session: Session):
+    response = client.get("/thing/select")
+    _assert_on_solr_response(mock_solr_query, response)
+
+
+@patch("isb_web.isb_solr_query.solr_query")
+def test_solr_select_get_with_slash(mock_solr_query: MagicMock, client: TestClient, session: Session):
+    response = client.get("/thing/select/")
+    _assert_on_solr_response(mock_solr_query, response)
+
+
+@patch("isb_web.isb_solr_query.solr_query")
+def test_solr_select_post(mock_solr_query: MagicMock, client: TestClient, session: Session):
+    response = client.post("/thing/select")
+    _assert_on_solr_response(mock_solr_query, response)
+
+
+@patch("isb_web.isb_solr_query.solr_query")
+def test_solr_select_post_with_slash(mock_solr_query: MagicMock, client: TestClient, session: Session):
+    response = client.post("/thing/select/")
+    _assert_on_solr_response(mock_solr_query, response)


### PR DESCRIPTION
Fix bug (https://github.com/isamplesorg/isamples_inabox/issues/334) that was requiring @rdhyee to hack around a python solr client library