### PR TITLE
For Post methods, support querying by including the parameters in the request body if it is encoded as JSON

### DIFF
--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -281,11 +281,20 @@ async def _get_solr_select(request: fastapi.Request):
         "q": defparams["q"]
     }
     params = []
-    # Update params with the provided parameters
-    for k, v in request.query_params.multi_items():
-        params.append([k, v])
-        if k in properties:
-            properties[k] = v
+    if request.method == "POST":
+        body = await request.body()
+        if request.headers.get("Content-Type").startswith("application/json"):
+            json_body = json.loads(body)
+            for k, v in json_body.items():
+                params.append([k, v])
+                if k in properties:
+                    properties[k] = v
+    else:
+        # Update params with the provided parameters
+        for k, v in request.query_params.multi_items():
+            params.append([k, v])
+            if k in properties:
+                properties[k] = v
     params = set_default_params(params, defparams)
     logging.warning(params)
     analytics.attach_analytics_state_to_request(AnalyticsEvent.THING_SOLR_SELECT, request, properties)

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -283,30 +283,7 @@ async def _get_solr_select(request: fastapi.Request):
     }
     params = []
     if request.method == "POST":
-        body = await request.body()
-        content_type = request.headers.get("Content-Type")
-        if content_type is None:
-            raise fastapi.HTTPException(
-                status_code=400,
-                detail="Content-Type header not present.  application/json is only supported Content-Type."
-            )
-        if not content_type.startswith("application/json"):
-            raise fastapi.HTTPException(
-                status_code=400,
-                detail=f"application/json is only supported Content-Type. {content_type} is not supported."
-            )
-        if content_type is not None and content_type.startswith("application/json"):
-            try:
-                json_body = json.loads(body)
-            except JSONDecodeError as e:
-                raise fastapi.HTTPException(
-                    status_code=400,
-                    detail=f"Request body is not valid JSON: {e}"
-                )
-            for k, v in json_body.items():
-                params.append([k, v])
-                if k in properties:
-                    properties[k] = v
+        await _handle_post_solr_select(params, properties, request)
     else:
         # Update params with the provided parameters
         for k, v in request.query_params.multi_items():
@@ -322,6 +299,33 @@ async def _get_solr_select(request: fastapi.Request):
     # before returning here, hence defeating the purpose of the streaming
     # response.
     return isb_solr_query.solr_query(params)
+
+
+async def _handle_post_solr_select(params, properties, request):
+    body = await request.body()
+    content_type = request.headers.get("Content-Type")
+    if content_type is None:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="Content-Type header not present.  application/json is only supported Content-Type."
+        )
+    if not content_type.startswith("application/json"):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f"application/json is only supported Content-Type. {content_type} is not supported."
+        )
+    if content_type is not None and content_type.startswith("application/json"):
+        try:
+            json_body = json.loads(body)
+        except JSONDecodeError as e:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=f"Request body is not valid JSON: {e}"
+            )
+        for k, v in json_body.items():
+            params.append([k, v])
+            if k in properties:
+                properties[k] = v
 
 
 # TODO: Don't blindly accept user input!

--- a/tests/test_fastapi_apps.py
+++ b/tests/test_fastapi_apps.py
@@ -288,11 +288,11 @@ def test_solr_select_get_with_slash(mock_solr_query: MagicMock, client: TestClie
 
 @patch("isb_web.isb_solr_query.solr_query")
 def test_solr_select_post(mock_solr_query: MagicMock, client: TestClient, session: Session):
-    response = client.post("/thing/select", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"}))
+    response = client.post("/thing/select", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"})) # type: ignore
     _assert_on_solr_response(mock_solr_query, response)
 
 
 @patch("isb_web.isb_solr_query.solr_query")
 def test_solr_select_post_with_slash(mock_solr_query: MagicMock, client: TestClient, session: Session):
-    response = client.post("/thing/select/", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"}))
+    response = client.post("/thing/select/", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"})) # type: ignore
     _assert_on_solr_response(mock_solr_query, response)

--- a/tests/test_fastapi_apps.py
+++ b/tests/test_fastapi_apps.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -287,11 +288,11 @@ def test_solr_select_get_with_slash(mock_solr_query: MagicMock, client: TestClie
 
 @patch("isb_web.isb_solr_query.solr_query")
 def test_solr_select_post(mock_solr_query: MagicMock, client: TestClient, session: Session):
-    response = client.post("/thing/select")
+    response = client.post("/thing/select", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"}))
     _assert_on_solr_response(mock_solr_query, response)
 
 
 @patch("isb_web.isb_solr_query.solr_query")
 def test_solr_select_post_with_slash(mock_solr_query: MagicMock, client: TestClient, session: Session):
-    response = client.post("/thing/select/")
+    response = client.post("/thing/select/", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"}))
     _assert_on_solr_response(mock_solr_query, response)

--- a/tests/test_fastapi_apps.py
+++ b/tests/test_fastapi_apps.py
@@ -288,11 +288,11 @@ def test_solr_select_get_with_slash(mock_solr_query: MagicMock, client: TestClie
 
 @patch("isb_web.isb_solr_query.solr_query")
 def test_solr_select_post(mock_solr_query: MagicMock, client: TestClient, session: Session):
-    response = client.post("/thing/select", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"})) # type: ignore
+    response = client.post("/thing/select", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"}))  # type: ignore
     _assert_on_solr_response(mock_solr_query, response)
 
 
 @patch("isb_web.isb_solr_query.solr_query")
 def test_solr_select_post_with_slash(mock_solr_query: MagicMock, client: TestClient, session: Session):
-    response = client.post("/thing/select/", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"})) # type: ignore
+    response = client.post("/thing/select/", headers={"Content-Type": "application/json; charset=utf-8"}, data=json.dumps({"foo": "bar"}))  # type: ignore
     _assert_on_solr_response(mock_solr_query, response)


### PR DESCRIPTION
As @rdhyee noted, we weren't properly read solr requests out of the body if the method was post (it was looking in the query string).  For post methods, it makes sense to read this out of the request body and expect it to be JSON.  This is what we are using to query solr, and this is what the solr documentation recommends.