### PR TITLE
Export client cli

### DIFF
--- a/isamples_export_client/export_client.py
+++ b/isamples_export_client/export_client.py
@@ -1,3 +1,6 @@
+import datetime
+import logging
+import time
 from enum import Enum
 import os
 
@@ -18,7 +21,13 @@ class ExportJobStatus(Enum):
         raise ValueError(f"No ExportJobStatus found for {raw_string}")
 
 class ExportClient:
-    def __init__(self, query: str, destination_directory: str, jwt: str, export_server_url: str, format: str, session: Session = requests.session()):
+    def __init__(self, query: str,
+                 destination_directory: str,
+                 jwt: str,
+                 export_server_url: str,
+                 format: str,
+                 session: Session = requests.session(),
+                 sleep_time: float = 5):
         self._query = query
         self._destination_directory = destination_directory
         self._jwt = jwt
@@ -27,6 +36,7 @@ class ExportClient:
         self._export_server_url = export_server_url
         self._format = format
         self._rsession = session
+        self._sleep_time = sleep_time
         try:
             os.makedirs(name=self._destination_directory, exist_ok=True)
         except OSError as e:
@@ -51,5 +61,36 @@ class ExportClient:
             return ExportJobStatus.string_to_enum(status)
         raise ValueError(f"Invalid response to export status: {response}")
 
-    def download(self, uuid: str) -> bool:
+    def download(self, uuid: str) -> str:
         """Download the exported result set to the specified destination"""
+        download_url = f"{self._export_server_url}download?uuid={uuid}"
+        with requests.get(download_url, stream=True) as r:
+            r.raise_for_status()
+            current_time = datetime.datetime.now()
+            date_string = current_time.strftime("%Y_%m_%d_%H_%M_%S")
+            filename = f"isamples_export_{date_string}.{self._format}"
+            local_filename = os.path.join(self._destination_directory, filename)
+            with open(local_filename, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            return local_filename
+
+    def perform_full_download(self):
+        logging.info("Contacting the export service to start the export process")
+        uuid = self.create()
+        logging.info(f"Contacted the export service, created export job with uuid {uuid}")
+        while True:
+            try:
+                status = self.status(uuid)
+                if status != ExportJobStatus.COMPLETED:
+                    time.sleep(self._sleep_time)
+                    logging.info(f"Export job still running, sleeping for {self._sleep_time} seconds")
+                    continue
+                else:
+                    logging.info(f"Export job completed, going to download")
+                    filename = self.download(uuid)
+                    logging.info(f"Successfully downloaded file to {filename}")
+            except Exception as e:
+                logging.error("An error occurred:", e)
+                # Sleep for a short time before retrying after an error
+                time.sleep(self._sleep_time)

--- a/isamples_export_client/export_client.py
+++ b/isamples_export_client/export_client.py
@@ -10,8 +10,7 @@ import requests
 from requests import Session, Response
 
 from isamples_metadata.solr_field_constants import SOLR_INDEX_UPDATED_TIME
-from isb_lib.core import datetimeToSolrStr, parsed_datetime_from_isamples_format
-from isb_web.isb_solr_query import escape_solr_query_term
+from isb_lib.core import datetimeToSolrStr
 
 START_TIME = "start_time"
 
@@ -76,7 +75,6 @@ class ExportClient:
             format = last_manifest_dict[FORMAT]
             refresh_date = last_manifest_dict[START_TIME]
             return ExportClient(query, refresh_dir, jwt, export_server_url, format, refresh_date)
-
 
     @classmethod
     def _manifest_file_path(cls, dir_path: str):

--- a/isamples_export_client/export_client.py
+++ b/isamples_export_client/export_client.py
@@ -1,0 +1,55 @@
+from enum import Enum
+import os
+
+import requests
+from requests import Session
+
+
+class ExportJobStatus(Enum):
+    CREATED = "created"
+    STARTED = "started"
+    COMPLETED = "completed"
+
+    @staticmethod
+    def string_to_enum(cls, raw_string: str) -> Enum:
+        for enum_value in ExportJobStatus:
+            if enum_value.value == raw_string:
+                return enum_value
+        raise ValueError(f"No ExportJobStatus found for {raw_string}")
+
+class ExportClient:
+    def __init__(self, query: str, destination_directory: str, jwt: str, export_server_url: str, format: str, session: Session = requests.session()):
+        self._query = query
+        self._destination_directory = destination_directory
+        self._jwt = jwt
+        if not export_server_url.endswith("/"):
+            export_server_url = f"{export_server_url}/"
+        self._export_server_url = export_server_url
+        self._format = format
+        self._rsession = session
+        try:
+            os.makedirs(name=self._destination_directory, exist_ok=True)
+        except OSError as e:
+            raise ValueError(f"Unable to create export directory at {self._destination_directory}")
+
+    def create(self) -> str:
+        """Create a new export job, and return the uuid associated with the job"""
+        create_url = f"{self._export_server_url}create?q={self._query}&format={self._format}"
+        response = self._rsession.get(create_url)
+        if response.status_code == 200:
+            json = response.json()
+            return json.get("uuid")
+        raise ValueError(f"Invalid response to export creation: {response}")
+
+    def status(self, uuid: str) -> ExportJobStatus:
+        """Check the status of the specified export job"""
+        status_url = f"{self._export_server_url}status?uuid={uuid}"
+        response = self._rsession.get(status_url)
+        if response.status_code == 200:
+            json = response.json()
+            status = json.get("status")
+            return ExportJobStatus.string_to_enum(status)
+        raise ValueError(f"Invalid response to export status: {response}")
+
+    def download(self, uuid: str) -> bool:
+        """Download the exported result set to the specified destination"""

--- a/isb_web/export.py
+++ b/isb_web/export.py
@@ -89,7 +89,7 @@ def _search_solr_and_export_results(export_job_id: str):
 
 
 @export_app.get("/create")
-async def create(request: fastapi.Request, export_format: TargetExportFormat = TargetExportFormat.CSV,
+async def create(request: fastapi.Request, export_format: TargetExportFormat = TargetExportFormat.JSONL,
                  session: Session = Depends(get_session)) -> JSONResponse:
     """Creates a new export job with the specified solr query"""
 

--- a/scripts/export_client/export_client_cli.py
+++ b/scripts/export_client/export_client_cli.py
@@ -8,13 +8,18 @@ from isamples_export_client.export_client import ExportClient
 @click.command()
 @click.option(
     "-q",
-    "--query", prompt=True,
+    "--query",
     help="The solr query to execute.",
 )
 @click.option(
     "-d",
-    "--destination", prompt=True,
+    "--destination",
     help="The destination directory where the downloaded content should be written.",
+)
+@click.option(
+    "-r",
+    "--refresh-dir",
+    help="If specified, will read the manifest.json out of an existing directory and re-execute the query to update results."
 )
 @click.option(
     "-t",
@@ -34,8 +39,11 @@ from isamples_export_client.export_client import ExportClient
     type=click.Choice(["jsonl", "csv"], case_sensitive=False),
     default="jsonl"
 )
-def main(query: str, destination: str, jwt: str, url: str, format: str):
-    client = ExportClient(query, destination, jwt, url, format)
+def main(query: str, destination: str, refresh_dir: str, jwt: str, url: str, format: str):
+    if (refresh_dir is None):
+        client = ExportClient(query, destination, jwt, url, format)
+    else:
+        client = ExportClient.from_existing_download(refresh_dir, jwt)
     client.perform_full_download()
 
 

--- a/scripts/export_client/export_client_cli.py
+++ b/scripts/export_client/export_client_cli.py
@@ -1,6 +1,4 @@
 import click
-import requests
-import time
 
 from isamples_export_client.export_client import ExportClient
 

--- a/scripts/export_client/export_client_cli.py
+++ b/scripts/export_client/export_client_cli.py
@@ -8,17 +8,17 @@ from isamples_export_client.export_client import ExportClient
 @click.command()
 @click.option(
     "-q",
-    "--query",
+    "--query", prompt=True,
     help="The solr query to execute.",
 )
 @click.option(
     "-d",
-    "--destination",
+    "--destination", prompt=True,
     help="The destination directory where the downloaded content should be written.",
 )
 @click.option(
     "-t",
-    "--jwt",
+    "--jwt", prompt=True,
     help="The JWT for the authenticated user.",
 )
 @click.option(
@@ -34,8 +34,8 @@ from isamples_export_client.export_client import ExportClient
     type=click.Choice(["jsonl", "csv"], case_sensitive=False),
     default="jsonl"
 )
-def main(query: str, destination: str, jwt: str, export_url: str, format: str):
-    client = ExportClient(query, destination, jwt, export_url, format)
+def main(query: str, destination: str, jwt: str, url: str, format: str):
+    client = ExportClient(query, destination, jwt, url, format)
     client.perform_full_download()
 
 

--- a/scripts/export_client/export_client_cli.py
+++ b/scripts/export_client/export_client_cli.py
@@ -1,0 +1,38 @@
+import click
+
+
+@click.command()
+@click.option(
+    "-q",
+    "--query",
+    help="The solr query to execute.",
+)
+@click.option(
+    "-d",
+    "--destination",
+    help="The destination directory where the downloaded content should be written.",
+)
+@click.option(
+    "-t",
+    "--jwt",
+    help="The JWT for the authenticated user.",
+)
+@click.option(
+    "-u",
+    "--url",
+    help="The URL to the iSamples server to export from.",
+    default="https://central.isample.xyz/isamples_central/export"
+)
+@click.option(
+    "-f",
+    "--format",
+    help="The format of the exported content.",
+    type=click.Choice(["jsonl", "csv"], case_sensitive=False),
+    default="jsonl"
+)
+def main():
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_client/export_client_cli.py
+++ b/scripts/export_client/export_client_cli.py
@@ -1,4 +1,8 @@
 import click
+import requests
+import time
+
+from isamples_export_client.export_client import ExportClient
 
 
 @click.command()
@@ -30,8 +34,9 @@ import click
     type=click.Choice(["jsonl", "csv"], case_sensitive=False),
     default="jsonl"
 )
-def main():
-    print()
+def main(query: str, destination: str, jwt: str, export_url: str, format: str):
+    client = ExportClient(query, destination, jwt, export_url, format)
+    client.perform_full_download()
 
 
 if __name__ == "__main__":

--- a/scripts/export_client/export_client_cli.py
+++ b/scripts/export_client/export_client_cli.py
@@ -27,7 +27,7 @@ from isamples_export_client.export_client import ExportClient
 @click.option(
     "-u",
     "--url",
-    help="The URL to the iSamples server to export from.",
+    help="The URL to the iSamples export service.",
     default="https://central.isample.xyz/isamples_central/export"
 )
 @click.option(


### PR DESCRIPTION
CLI wrapper around the export client.  Has ability to refresh previous downloads.

```
Usage: export_client_cli.py [OPTIONS]

Options:
  -q, --query TEXT          The solr query to execute.
  -d, --destination TEXT    The destination directory where the downloaded
                            content should be written.
  -r, --refresh-dir TEXT    If specified, will read the manifest.json out of
                            an existing directory and re-execute the query to
                            update results.
  -t, --jwt TEXT            The JWT for the authenticated user.
  -u, --url TEXT            The URL to the iSamples export service.
  -f, --format [jsonl|csv]  The format of the exported content.
  --help                    Show this message and exit.
```