### PR TITLE
Handle errors when sending solr requests

### DIFF
--- a/isb_lib/models/export_job.py
+++ b/isb_lib/models/export_job.py
@@ -68,3 +68,9 @@ class ExportJob(SQLModel, table=True):
         description="The path to the exported file.",
         index=False
     )
+    error: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        description="Details about an error with the export job.",
+        index=False
+    )

--- a/isb_web/export.py
+++ b/isb_web/export.py
@@ -64,6 +64,7 @@ def _handle_error(session: Session, export_job: ExportJob, error: str):
     export_job.error = error
     sqlmodel_database.save_or_update_export_job(session, export_job)
 
+
 def _search_solr_and_export_results(export_job_id: str):
     """Task function that gets a queued export job from the db, executes the solr query, and writes results to disk"""
 

--- a/isb_web/export.py
+++ b/isb_web/export.py
@@ -1,9 +1,11 @@
+import datetime
 import logging
 import os.path
 import traceback
 import urllib
 from typing import Optional
 import concurrent
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 import fastapi.responses
@@ -57,6 +59,11 @@ def search_solr_and_export_results(export_job_id: str):
         traceback.print_tb(e.__traceback__)
 
 
+def _handle_error(session: Session, export_job: ExportJob, error: str):
+    export_job.tcompleted = datetime.datetime.now()
+    export_job.error = error
+    sqlmodel_database.save_or_update_export_job(session, export_job)
+
 def _search_solr_and_export_results(export_job_id: str):
     """Task function that gets a queued export job from the db, executes the solr query, and writes results to disk"""
 
@@ -72,7 +79,14 @@ def _search_solr_and_export_results(export_job_id: str):
             encoded_params = urllib.parse.urlencode(solr_query_params)  # type: ignore
             export_handler = isb_solr_query.get_solr_url("export")
             full_url = f"{export_handler}?{encoded_params}"
-            src = urlopen(full_url)
+            try:
+                src = urlopen(full_url)
+            except HTTPError as e:
+                _handle_error(session, export_job, f"HTTP Error, code: {e.code} reason: {e.reason}")
+                return
+            except Exception as e:
+                _handle_error(session, export_job, f"Export Error {str(e)}")
+                return
             docs = ijson.items(src, "response.docs.item", use_float=True)
             generator_docs = (doc for doc in docs)
             transformed_response_path = f"/tmp/{export_job.uuid}"
@@ -131,7 +145,10 @@ def status(uuid: str = fastapi.Query(None), session: Session = Depends(get_sessi
         return _not_found_response()
     else:
         if export_job.tcompleted is not None:
-            content = {"status": "completed", "tcompleted": str(export_job.tcompleted)}
+            if export_job.error is None:
+                content = {"status": "completed", "tcompleted": str(export_job.tcompleted)}
+            else:
+                content = {"status": "error", "tcompleted": str(export_job.tcompleted), "reason": export_job.error}
             return fastapi.responses.JSONResponse(content=content, status_code=HTTP_200_OK)
         elif export_job.tstarted is not None:
             content = {"status": "started", "tstarted": str(export_job.tstarted)}


### PR DESCRIPTION
Fix the bug that @smrgeoinfo found when attempting to use the export service.  It's very easy to send a malformed query to solr that results in a 400 error.  We now respond appropriately, and the export client CLI also handles these responses appropriately:

```
WARNING:root:Export job failed with error.  Check that your solr query is valid and try again.  Response: {'status': 'error', 'tcompleted': '2024-04-24 14:19:31.131047', 'reason': 'HTTP Error, code: 400 reason: Bad Request'}
```