### PR TITLE
Config switch taxon cache

### DIFF
--- a/isamples_metadata/GEOMETransformer.py
+++ b/isamples_metadata/GEOMETransformer.py
@@ -150,10 +150,12 @@ class GEOMETransformer(Transformer):
 
         return Transformer.DESCRIPTION_SEPARATOR.join(description_pieces)
 
-
     def _look_up_kingdom_for_taxonomy_name(self, taxonomy_name: str) -> Optional[str]:
         if self._taxonomy_name_to_kingdom_map is None or len(self._taxonomy_name_to_kingdom_map) == 0:
-            return kingdom_for_taxonomy_name(self._session, taxonomy_name)
+            if self._session is not None:
+                return kingdom_for_taxonomy_name(self._session, taxonomy_name)
+            else:
+                return None
         else:
             return self._taxonomy_name_to_kingdom_map.get(taxonomy_name)
 

--- a/isb_web/config.py
+++ b/isb_web/config.py
@@ -98,6 +98,10 @@ class Settings(BaseSettings):
     modelserver_url = "http://localhost:9000/"
     modelserver_lru_cache_size = 10000
 
+    # Whether to prefetch all the taxonomic names at app startup.  Useful for batch processing and reindexing, but
+    # uses a lot of memory so shouldn't be enabled by default.
+    taxon_cache_enabled: bool = False
+
     class Config:
         env_file = "isb_web_config.env"
         case_sensitive = False

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -157,7 +157,8 @@ def on_startup():
     vocabulary_mapper.specimen_type()
     # Force this into memory so it's cached when we need it later
     global TAXONOMY_NAME_TO_KINGDOM_MAP
-    TAXONOMY_NAME_TO_KINGDOM_MAP = taxonomy_name_to_kingdom_map(session)
+    if config.Settings().taxon_cache_enabled:
+        TAXONOMY_NAME_TO_KINGDOM_MAP = taxonomy_name_to_kingdom_map(session)
     session.close()
     # Superusers are allowed to mint identifiers as well, so make sure they're in the list.
     orcid_ids.extend(isb_web.config.Settings().orcid_superusers)


### PR DESCRIPTION
On Wednesday, discovered that the increased memory usage of the taxon cache was causing the system memory to be exhausted so that the solr instance kept getting killed.  Turn this cache off and allow it to be enabled via config if necessary.