### PR TITLE
Local contexts

### DIFF
--- a/isamples_metadata/GEOMETransformer.py
+++ b/isamples_metadata/GEOMETransformer.py
@@ -500,8 +500,15 @@ class GEOMETransformer(Transformer):
         return []
 
     def complies_with(self) -> typing.List[str]:
-        # Don't have this information
-        return []
+        local_contexts_id = self.local_contexts_id()
+        if local_contexts_id is not None:
+            return [f"localcontexts:https://localcontextshub.org/projects/{local_contexts_id}"]
+        else:
+            # Don't have this information
+            return []
+
+    def local_contexts_id(self) -> Optional[str]:
+        return self.source_record.get("localContextsId")
 
     @staticmethod
     def _format_result_object(authorized_by: list[str]) -> dict[str, list[str]]:
@@ -661,10 +668,6 @@ class GEOMEChildTransformer(GEOMETransformer):
         return [parent_dict]
 
     def authorized_by(self) -> typing.List[str]:
-        # If present, this information is stored on the parent record
-        return []
-
-    def complies_with(self) -> typing.List[str]:
         # If present, this information is stored on the parent record
         return []
 

--- a/isamples_metadata/GEOMETransformer.py
+++ b/isamples_metadata/GEOMETransformer.py
@@ -512,7 +512,7 @@ class GEOMETransformer(Transformer):
 
     @staticmethod
     def complies_with_list_for_local_contexts_id(local_contexts_id: str) -> list[str]:
-        return [f"localcontexts:https://localcontextshub.org/projects/{local_contexts_id}"]
+        return [f"localcontexts:projects/{local_contexts_id}"]
 
     @staticmethod
     def _format_result_object(authorized_by: list[str]) -> dict[str, list[str]]:

--- a/isamples_metadata/GEOMETransformer.py
+++ b/isamples_metadata/GEOMETransformer.py
@@ -510,7 +510,6 @@ class GEOMETransformer(Transformer):
     def local_contexts_id(self) -> Optional[str]:
         return self.source_record.get("localContextsId")
 
-
     @staticmethod
     def complies_with_list_for_local_contexts_id(local_contexts_id: str) -> list[str]:
         return [f"localcontexts:https://localcontextshub.org/projects/{local_contexts_id}"]

--- a/isamples_metadata/GEOMETransformer.py
+++ b/isamples_metadata/GEOMETransformer.py
@@ -502,13 +502,18 @@ class GEOMETransformer(Transformer):
     def complies_with(self) -> typing.List[str]:
         local_contexts_id = self.local_contexts_id()
         if local_contexts_id is not None:
-            return [f"localcontexts:https://localcontextshub.org/projects/{local_contexts_id}"]
+            return GEOMETransformer.complies_with_list_for_local_contexts_id(local_contexts_id)
         else:
             # Don't have this information
             return []
 
     def local_contexts_id(self) -> Optional[str]:
         return self.source_record.get("localContextsId")
+
+
+    @staticmethod
+    def complies_with_list_for_local_contexts_id(local_contexts_id: str) -> list[str]:
+        return [f"localcontexts:https://localcontextshub.org/projects/{local_contexts_id}"]
 
     @staticmethod
     def _format_result_object(authorized_by: list[str]) -> dict[str, list[str]]:

--- a/isb_lib/geome_adapter.py
+++ b/isb_lib/geome_adapter.py
@@ -70,7 +70,7 @@ class GEOMEIdentifierIterator(isb_lib.core.IdentifierIterator):
         )
         self._record_type = record_type
         self._project_ids = None
-        self._project_ids_to_local_context_ids = {}
+        self._project_ids_to_local_context_ids: dict[str, str] = {}
         self._project_id = project_id
 
     def listProjects(self):
@@ -354,9 +354,10 @@ def loadThing(identifier: str, t_created: datetime.datetime, existing_thing: Opt
         obj = response.json()
     except Exception as e:
         L.warning(e)
-    project_id = obj.get("projectId")
-    local_contexts_id = ids.local_contexts_id_for_project_id(project_id)
-    set_localcontexts_id_in_resolved_content(local_contexts_id, obj)
+    if obj is not None:
+        project_id = obj.get("projectId")
+        local_contexts_id = ids.local_contexts_id_for_project_id(project_id)
+        set_localcontexts_id_in_resolved_content(local_contexts_id, obj)
     if existing_thing is None:
         item = GEOMEItem(identifier, obj)
         thing = item.asThing(identifier, t_created, r_status, r_url, t_resolved, elapsed, media_type)
@@ -372,8 +373,8 @@ def loadThing(identifier: str, t_created: datetime.datetime, existing_thing: Opt
     return thing
 
 
-def set_localcontexts_id_in_resolved_content(local_contexts_id: Optional[str], resolved_content: dict):
-    if local_contexts_id is not None:
+def set_localcontexts_id_in_resolved_content(local_contexts_id: Optional[str], resolved_content: Optional[dict]):
+    if local_contexts_id is not None and resolved_content is not None:
         resolved_content["localContextsId"] = local_contexts_id
 
 

--- a/isb_lib/geome_adapter.py
+++ b/isb_lib/geome_adapter.py
@@ -130,9 +130,9 @@ class GEOMEIdentifierIterator(isb_lib.core.IdentifierIterator):
                         "q": f"_expeditions_:{expedition_dict['expeditionCode']}",
                     }
                     while more_work:
-                        expedition_records_url = f"{GEOME_API}records/Sample/json"
+                        self.expedition_records_url = f"{GEOME_API}records/Sample/json"
                         response = requests.get(
-                            expedition_records_url, params=params, headers=headers, timeout=HTTP_TIMEOUT
+                            self.expedition_records_url, params=params, headers=headers, timeout=HTTP_TIMEOUT
                         )
                         if response.status_code != 200:
                             L.error(

--- a/isb_lib/geome_adapter.py
+++ b/isb_lib/geome_adapter.py
@@ -104,7 +104,6 @@ class GEOMEIdentifierIterator(isb_lib.core.IdentifierIterator):
     def local_contexts_id_for_project_id(self, project_id: str) -> Optional[str]:
         return self._project_ids_to_local_context_ids.get(project_id)
 
-
     def recordsInProject(self, project_id, record_type):
         L = getLogger()
         L.debug("recordsInProject project %s", project_id)
@@ -376,7 +375,6 @@ def loadThing(identifier: str, t_created: datetime.datetime, existing_thing: Opt
 def set_localcontexts_id_in_resolved_content(local_contexts_id: Optional[str], resolved_content: dict):
     if local_contexts_id is not None:
         resolved_content["localContextsId"] = local_contexts_id
-
 
 
 def reloadThing(thing):

--- a/scripts/geome_things.py
+++ b/scripts/geome_things.py
@@ -15,7 +15,8 @@ import click_config_file
 from isamples_metadata.GEOMETransformer import GEOMETransformer
 from isb_lib import geome_adapter
 from isb_lib.core import MEDIA_JSON
-from isb_lib.geome_adapter import GEOMEIdentifierIterator
+from isb_lib.geome_adapter import GEOMEIdentifierIterator, set_localcontexts_id_in_resolved_content
+from isb_lib.models import thing
 from isb_lib.models.thing import Thing
 from isb_web import sqlmodel_database
 from isb_web.sqlmodel_database import SQLModelDAO, get_thing_with_id, save_thing, all_thing_primary_keys, \
@@ -30,10 +31,10 @@ def getLogger():
     return logging.getLogger("main")
 
 
-def wrapLoadThing(ark: str, tc: datetime.datetime, existing_thing: Optional[Thing] = None):
+def wrapLoadThing(ark: str, tc: datetime.datetime, existing_thing: thing, ids: GEOMEIdentifierIterator):
     """Return request information to assist future management"""
     try:
-        return ark, tc, isb_lib.geome_adapter.loadThing(ark, tc, existing_thing)
+        return ark, tc, isb_lib.geome_adapter.loadThing(ark, tc, existing_thing, ids)
     except Exception:
         pass
     return ark, tc, None
@@ -45,12 +46,12 @@ def countThings(session):
     return cnt
 
 
-async def _loadGEOMEEntries(session, max_count, start_from=None):  # noqa: C901 -- need to examine computational complexity
+async def _loadGEOMEEntries(session, max_count, start_from=None, project_id: int = 0):  # noqa: C901 -- need to examine computational complexity
     L = getLogger()
     futures = []
     working = {}
     ids = isb_lib.geome_adapter.GEOMEIdentifierIterator(
-        max_entries=countThings(session) + max_count, date_start=start_from
+        max_entries=countThings(session) + max_count, date_start=start_from, project_id=project_id
     )
     # i = 0
     # for id in ids:
@@ -82,9 +83,9 @@ async def _loadGEOMEEntries(session, max_count, start_from=None):  # noqa: C901 
                     existing_thing = get_thing_with_id(session, identifier)
                     if existing_thing is not None:
                         logging.debug("Already have %s at %s", identifier, _id[1])
-                        future = executor.submit(wrapLoadThing, identifier, _id[1], existing_thing)
+                        future = executor.submit(wrapLoadThing, identifier, _id[1], existing_thing, ids)
                     else:
-                        future = executor.submit(wrapLoadThing, identifier, _id[1])
+                        future = executor.submit(wrapLoadThing, identifier, _id[1], None, ids)
                     futures.append(future)
                     working[identifier] = 0
                     total_requested += 1
@@ -123,7 +124,7 @@ async def _loadGEOMEEntries(session, max_count, start_from=None):  # noqa: C901 
                                 identifier,
                                 working[identifier],
                             )
-                            future = executor.submit(wrapLoadThing, identifier, tc)
+                            future = executor.submit(wrapLoadThing, identifier, tc, None, ids)
                             futures.append(future)
                         else:
                             L.error("Too many retries on %s", identifier)
@@ -143,10 +144,10 @@ async def _loadGEOMEEntries(session, max_count, start_from=None):  # noqa: C901 
             )
 
 
-def loadGEOMEEntries(session, max_count, start_from=None):
+def loadGEOMEEntries(session, max_count, start_from=None, project_id: int = 0):
     loop = asyncio.get_event_loop()
     future = asyncio.ensure_future(
-        _loadGEOMEEntries(session, max_count, start_from=start_from)
+        _loadGEOMEEntries(session, max_count, start_from=start_from, project_id=project_id)
     )
     loop.run_until_complete(future)
 
@@ -175,8 +176,15 @@ def main(ctx, db_url, solr_url, verbosity):
     default=1000,
     help="Maximum records to load, -1 for all",
 )
+@click.option(
+    "-p",
+    "--project_id",
+    type=int,
+    default=0,
+    help="The project id to fetch records for",
+)
 @click.pass_context
-def loadRecords(ctx, max_records):
+def loadRecords(ctx, max_records, project_id: int):
     L = getLogger()
     L.info("loadRecords, max = %s", max_records)
     if max_records == -1:
@@ -184,12 +192,15 @@ def loadRecords(ctx, max_records):
 
     session = SQLModelDAO((ctx.obj["db_url"])).get_session()
     try:
-        max_created = sqlmodel_database.last_time_thing_created(
-            session, isb_lib.geome_adapter.GEOMEItem.AUTHORITY_ID
-        )
-        logging.info("Oldest = %s", max_created)
+        if project_id == 0:
+            max_created = sqlmodel_database.last_time_thing_created(
+                session, isb_lib.geome_adapter.GEOMEItem.AUTHORITY_ID
+            )
+            logging.info("Oldest = %s", max_created)
+        else:
+            max_created = None
         time.sleep(1)
-        loadGEOMEEntries(session, max_records, start_from=max_created)
+        loadGEOMEEntries(session, max_records, start_from=max_created, project_id=project_id)
     finally:
         session.close()
 
@@ -355,24 +366,22 @@ def harvest_local_contexts(cts, batch_size: int):
     identifier_iterator = GEOMEIdentifierIterator()
     for project_dict in identifier_iterator.listProjects():
         thing_identifiers_for_project = []
-        local_contexts_id = project_dict.get("localcontextsId")
+        project_id = project_dict.get("projectId")
+        local_contexts_id = identifier_iterator.local_contexts_id_for_project_id(project_id)
         if local_contexts_id is not None:
             # If the project has a localcontextsId, we need to propagate down to all records in the project
             print(f"Found localcontextsId for project {project_dict}")
-            project_id = project_dict.get("projectId")
             count = 0
-            for record in identifier_iterator.recordsInProject(project_id, identifier_iterator._record_type, local_contexts_id):
+            for record in identifier_iterator.recordsInProject(project_id, identifier_iterator._record_type):
                 count += 1
                 identifier = record[0].get("bcid", None)
                 thing_identifiers_for_project.append(identifier)
             # Now refetch all the things with specified identifier and stuff in the localcontextsId into resolved_content
             things_for_project = get_things_with_ids(session, thing_identifiers_for_project)
             for thing in things_for_project:
-                thing.resolved_content["localContextsId"] = local_contexts_id
+                set_localcontexts_id_in_resolved_content(local_contexts_id, thing.resolved_content)
                 bulk_updater.add_thing(thing.resolved_content, thing.id, thing.resolved_url, thing.resolved_status,
                                        thing.h3, thing.tcreated)
-
-            #
             project_title = project_dict.get("projectTitle")
             print(f"{count} records in project {project_title}")
             bulk_updater.finish()

--- a/scripts/migrations/solr/add_local_contexts_ids.py
+++ b/scripts/migrations/solr/add_local_contexts_ids.py
@@ -1,0 +1,91 @@
+import logging
+from typing import Optional
+
+import click
+import click_config_file
+import requests
+from sqlmodel import Session
+
+import isb_lib.core
+import isb_web.config
+import isb_lib.sesar_adapter
+from isamples_metadata.GEOMETransformer import GEOMETransformer
+from isb_lib.models.thing import Thing
+from isb_web.isb_solr_query import ISBCoreSolrRecordIterator
+from isb_web.sqlmodel_database import SQLModelDAO, paged_things_with_ids
+
+
+@click.command()
+@click_config_file.configuration_option(config_file_name="isb.cfg")
+@click.pass_context
+def main(ctx):
+    solr_url = isb_web.config.Settings().solr_url
+    db_url = isb_web.config.Settings().database_url
+    isb_lib.core.things_main(ctx, db_url, solr_url)
+    session = SQLModelDAO((ctx.obj["db_url"]), echo=True).get_session()
+    geome_things_with_local_contexts_ids = fetch_geome_things_with_local_contexts_id(session)
+    add_local_contexts_ids(solr_url, geome_things_with_local_contexts_ids)
+
+
+def add_local_contexts_ids(solr_url: str, geome_things: dict[str, Thing]):
+    total_records = 0
+    batch_size = 50000
+    current_mutated_batch = []
+    rsession = requests.session()
+    iterator = ISBCoreSolrRecordIterator(
+        rsession, "source:GEOME", batch_size, 0, "id asc"
+    )
+    for record in iterator:
+        identifier = record.get("id")
+        if identifier not in geome_things:
+            continue
+        geome_thing = geome_things.get(identifier)
+        mutated_record = mutate_record(record, geome_thing)  # type: ignore
+        if mutated_record is not None:
+            current_mutated_batch.append(mutated_record)
+        if len(current_mutated_batch) == 1:
+            save_mutated_batch(current_mutated_batch, rsession, solr_url)
+            current_mutated_batch = []
+        total_records += 1
+    if len(current_mutated_batch) > 0:
+        # handle the remainder
+        save_mutated_batch(current_mutated_batch, rsession, solr_url)
+    logging.info(f"Finished iterating, visited {total_records} records")
+
+
+def save_mutated_batch(current_mutated_batch, rsession, solr_url):
+    logging.info(f"Going to save {len(current_mutated_batch)} records")
+    isb_lib.core.solrAddRecords(rsession, current_mutated_batch, solr_url)
+    isb_lib.core.solrCommit(rsession, solr_url)
+    logging.info(f"Just saved {len(current_mutated_batch)} records")
+
+
+def mutate_record(record: dict, geome_thing: Thing) -> Optional[dict]:
+    assert geome_thing.resolved_content is not None
+    local_contexts_id = geome_thing.resolved_content.get("localContextsId")
+    if local_contexts_id is None:
+        return None
+    else:
+        complies_with_list = GEOMETransformer.complies_with_list_for_local_contexts_id(local_contexts_id)
+        record_copy = record.copy()
+        record_copy["compliesWith"] = complies_with_list
+        return record_copy
+
+
+def fetch_geome_things_with_local_contexts_id(session: Session) -> dict[str, Thing]:
+    geome_things_with_local_contexts_ids: dict[str, Thing] = {}
+    all_geome_things = paged_things_with_ids(session, "GEOME", limit=1000000000000)
+    for current_geome_thing in all_geome_things:
+        assert current_geome_thing.resolved_content is not None
+        local_contexts_id = current_geome_thing.resolved_content.get("localContextsId")
+        if local_contexts_id is not None:
+            assert current_geome_thing.id is not None
+            geome_things_with_local_contexts_ids[current_geome_thing.id] = current_geome_thing
+    return geome_things_with_local_contexts_ids
+
+
+"""
+Populates local_context_ids for existing GEOME records
+"""
+if __name__ == "__main__":
+    main()

--- a/tests/test_data/GEOME/raw/ark-21547-Car2PIRE_0334.json
+++ b/tests/test_data/GEOME/raw/ark-21547-Car2PIRE_0334.json
@@ -51,5 +51,6 @@
             "tissueCatalogNumber": "http://n2t.net/ark:/21547/Q2INDO106431.1"
         }
     ],
-    "projectId": 80
+    "projectId": 80,
+    "localContextsId": 123456
 }

--- a/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-child-test.json
+++ b/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-child-test.json
@@ -101,7 +101,9 @@
         }
     ],
     "authorized_by": [],
-    "complies_with": [],
+    "complies_with": [
+        "localcontexts:https://localcontextshub.org/projects/123456"
+    ],
     "producedBy_samplingSite_location_h3_0": "8065fffffffffff",
     "producedBy_samplingSite_location_h3_1": "81643ffffffffff",
     "producedBy_samplingSite_location_h3_2": "826557fffffffff",

--- a/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-child-test.json
+++ b/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-child-test.json
@@ -102,7 +102,7 @@
     ],
     "authorized_by": [],
     "complies_with": [
-        "localcontexts:https://localcontextshub.org/projects/123456"
+        "localcontexts:projects/123456"
     ],
     "producedBy_samplingSite_location_h3_0": "8065fffffffffff",
     "producedBy_samplingSite_location_h3_1": "81643ffffffffff",

--- a/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-test.json
+++ b/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-test.json
@@ -121,7 +121,7 @@
         ""
     ],
     "complies_with": [
-        "localcontexts:https://localcontextshub.org/projects/123456"
+        "localcontexts:projects/123456"
     ],
     "producedBy_samplingSite_location_h3_0": "8065fffffffffff",
     "producedBy_samplingSite_location_h3_1": "81643ffffffffff",

--- a/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-test.json
+++ b/tests/test_data/GEOME/test/ark-21547-Car2PIRE_0334-test.json
@@ -120,7 +120,9 @@
     "authorized_by": [
         ""
     ],
-    "complies_with": [],
+    "complies_with": [
+        "localcontexts:https://localcontextshub.org/projects/123456"
+    ],
     "producedBy_samplingSite_location_h3_0": "8065fffffffffff",
     "producedBy_samplingSite_location_h3_1": "81643ffffffffff",
     "producedBy_samplingSite_location_h3_2": "826557fffffffff",

--- a/tests/test_isamples_metadata.py
+++ b/tests/test_isamples_metadata.py
@@ -16,6 +16,7 @@ from isamples_metadata.SESARTransformer import SESARTransformer
 from isamples_metadata.GEOMETransformer import GEOMETransformer, GEOMEChildTransformer
 from isamples_metadata.OpenContextTransformer import OpenContextTransformer
 from isamples_metadata.SmithsonianTransformer import SmithsonianTransformer
+from isamples_metadata.metadata_constants import METADATA_COMPLIES_WITH
 from isamples_metadata.taxonomy.metadata_model_client import ModelServerClient, PredictionResult
 from isb_lib import geome_adapter, sesar_adapter
 from isb_lib.geome_adapter import GEOMEItem
@@ -193,6 +194,8 @@ def test_geome_child_dicts_equal(
         transformed_to_isamples_record = child_transformer.transform()
         _assert_transformed_dictionary(isamples_path, transformed_to_isamples_record)
         assert last_mod_str == child_transformer.last_updated_time()
+        # Also make sure the child picks up the localContextsId from the parent
+        assert transformed_to_isamples_record.get(METADATA_COMPLIES_WITH)[0] == "localcontexts:https://localcontextshub.org/projects/123456"
 
 
 # test the special logic in GEOME to grab the proper transformer

--- a/tests/test_isamples_metadata.py
+++ b/tests/test_isamples_metadata.py
@@ -197,7 +197,7 @@ def test_geome_child_dicts_equal(
         # Also make sure the child picks up the localContextsId from the parent
         complies_with = transformed_to_isamples_record.get(METADATA_COMPLIES_WITH)
         assert complies_with is not None
-        assert complies_with[0] == "localcontexts:https://localcontextshub.org/projects/123456"
+        assert complies_with[0] == "localcontexts:projects/123456"
 
 
 # test the special logic in GEOME to grab the proper transformer

--- a/tests/test_isamples_metadata.py
+++ b/tests/test_isamples_metadata.py
@@ -195,7 +195,9 @@ def test_geome_child_dicts_equal(
         _assert_transformed_dictionary(isamples_path, transformed_to_isamples_record)
         assert last_mod_str == child_transformer.last_updated_time()
         # Also make sure the child picks up the localContextsId from the parent
-        assert transformed_to_isamples_record.get(METADATA_COMPLIES_WITH)[0] == "localcontexts:https://localcontextshub.org/projects/123456"
+        complies_with = transformed_to_isamples_record.get(METADATA_COMPLIES_WITH)
+        assert complies_with is not None
+        assert complies_with[0] == "localcontexts:https://localcontextshub.org/projects/123456"
 
 
 # test the special logic in GEOME to grab the proper transformer


### PR DESCRIPTION
Support for local contexts in GEOME.  Write the `local_contexts_id` into each thing's `resolved_content`.  

Add a new command to harvest all the `local_context_id` for existing GEOME records.