### PR TITLE
Add a link to the original record

### DIFF
--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -243,7 +243,7 @@ async def get_thing_page(request: fastapi.Request, identifier: str, session: Ses
             "logout_url": logout_url,
             "localcontexts_info": local_contexts_info_for_resolved_content(content),
             "original_link": original_link,
-            "authority": item.authority_id
+            "original_authority": item.authority_id
         }
     )
 

--- a/isb_web/main.py
+++ b/isb_web/main.py
@@ -221,6 +221,7 @@ async def get_thing_page(request: fastapi.Request, identifier: str, session: Ses
         item_ispartof = "https://n2t.net"
     elif item.id.startswith("IGSN"):
         item_ispartof = "https://igsn.org"
+    original_link = f"{item_ispartof}/{item.id}"
     content = await thing_resolved_content(identifier, item, session)
     content_str = json.dumps(content)
     base_url = str(request.url)
@@ -240,7 +241,9 @@ async def get_thing_page(request: fastapi.Request, identifier: str, session: Ses
             "hypothesis_api_url": config.Settings().hypothesis_server_url,
             "login_url": login_url,
             "logout_url": logout_url,
-            "localcontexts_info": local_contexts_info_for_resolved_content(content)
+            "localcontexts_info": local_contexts_info_for_resolved_content(content),
+            "original_link": original_link,
+            "authority": item.authority_id
         }
     )
 

--- a/isb_web/templates/thing.html
+++ b/isb_web/templates/thing.html
@@ -103,7 +103,7 @@ window.addEventListener('load', fetchGrantToken('{{ authority|safe }}', '{{ isam
           </div>
           <div class="card">
             <div class="card-header">Original Record</div>
-            <div class="card-body">{{ authority }}: <a href="{{ original_link }}" target="_blank" rel="noopener noreferrer">{{ thing_identifier }}</div>
+            <div class="card-body">{{ original_authority }}: <a href="{{ original_link }}" target="_blank" rel="noopener noreferrer">{{ thing_identifier }}</div>
           </div>
           <div>
             <h5>Map Data</h5>

--- a/isb_web/templates/thing.html
+++ b/isb_web/templates/thing.html
@@ -101,6 +101,10 @@ window.addEventListener('load', fetchGrantToken('{{ authority|safe }}', '{{ isam
             <div class="card-header">Citation</div>
             <div id="citation" class="card-body"></div>
           </div>
+          <div class="card">
+            <div class="card-header">Original Record</div>
+            <div class="card-body">{{ authority }}: <a href="{{ original_link }}" target="_blank" rel="noopener noreferrer">{{ thing_identifier }}</div>
+          </div>
           <div>
             <h5>Map Data</h5>
             <div id="map"></div>


### PR DESCRIPTION
Since we are now linking iSamples records in the list to the iSamples page, make sure that page has a link to the original record.

![image](https://github.com/isamplesorg/isamples_inabox/assets/1188978/d66dcdd6-0abc-44a2-b0b6-f995ccb1e732)
