### PR TITLE
Use the right mapping for source_updated_time, so we don't reindex everything all the time

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -24,11 +24,11 @@ from isamples_metadata.metadata_constants import METADATA_SAMPLE_IDENTIFIER, MET
     METADATA_CURATION, METADATA_ACCESS_CONSTRAINTS, METADATA_RESPONSIBILITY, \
     METADATA_RELATED_RESOURCE, METADATA_DESCRIPTION, METADATA_HAS_SAMPLE_OBJECT_TYPE_CONFIDENCE, \
     METADATA_CURATION_LOCATION, METADATA_SAMPLE_LOCATION, METADATA_KEYWORD, METADATA_NAME, \
-    METADATA_ROLE, METADATA_IDENTIFIER
+    METADATA_ROLE, METADATA_IDENTIFIER, METADATA_LAST_MODIFIED_TIME
 from isamples_metadata.metadata_exceptions import MetadataException
 from isamples_metadata.solr_field_constants import SOLR_PRODUCED_BY_SAMPLING_SITE_ELEVATION_IN_METERS, \
     SOLR_CURATION_LABEL, SOLR_CURATION_DESCRIPTION, SOLR_CURATION_ACCESS_CONSTRAINTS, SOLR_CURATION_LOCATION, \
-    SOLR_CURATION_RESPONSIBILITY
+    SOLR_CURATION_RESPONSIBILITY, SOLR_SOURCE_UPDATED_TIME
 from isamples_metadata.vocabularies import vocabulary_mapper
 from isb_lib.models.thing import Thing
 from isamples_metadata.Transformer import Transformer, geo_to_h3
@@ -214,8 +214,8 @@ def _coreRecordAsSolrDoc(coreMetadata: typing.Dict) -> typing.Dict:  # noqa: C90
         "isb_core_id": coreMetadata[METADATA_AT_ID],
         "indexUpdatedTime": datetimeToSolrStr(igsn_lib.time.dtnow())
     }
-    if _shouldAddMetadataValueToSolrDoc(coreMetadata, "sourceUpdatedTime"):
-        doc["sourceUpdatedTime"] = coreMetadata["sourceUpdatedTime"]
+    if _shouldAddMetadataValueToSolrDoc(coreMetadata, METADATA_LAST_MODIFIED_TIME):
+        doc[SOLR_SOURCE_UPDATED_TIME] = coreMetadata[METADATA_LAST_MODIFIED_TIME]
     if _shouldAddMetadataValueToSolrDoc(coreMetadata, METADATA_LABEL):
         doc["label"] = coreMetadata[METADATA_LABEL]
     if _shouldAddMetadataValueToSolrDoc(coreMetadata, METADATA_DESCRIPTION):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import json
 import requests
 
 from isamples_metadata.metadata_constants import METADATA_KEYWORDS
+from isamples_metadata.solr_field_constants import SOLR_SOURCE_UPDATED_TIME
 from isb_lib.core import things_main
 
 TEST_LIVE_SERVER = 0
@@ -410,11 +411,13 @@ def test_core_record_as_solr_doc_3():
   "producedBy_samplingSite_location_h3_11": "8b3e6dca5012fff",
   "producedBy_samplingSite_location_h3_12": "8c3e6dca50121ff",
   "producedBy_samplingSite_location_h3_13": "8d3e6dca50120bf",
-  "producedBy_samplingSite_location_h3_14": "8e3e6dca50120b7"
+  "producedBy_samplingSite_location_h3_14": "8e3e6dca50120b7",
+  "last_modified_time":"2009-07-16T00:00:00Z"  
 }
 """
     solr_dict = _try_to_add_solr_doc(core_doc_str)
     assert "fossils" in solr_dict.get(METADATA_KEYWORDS)
+    assert solr_dict.get(SOLR_SOURCE_UPDATED_TIME) is not None
 
 
 def _load_test_file_into_solr_doc(file_path: str) -> dict:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -412,7 +412,7 @@ def test_core_record_as_solr_doc_3():
   "producedBy_samplingSite_location_h3_12": "8c3e6dca50121ff",
   "producedBy_samplingSite_location_h3_13": "8d3e6dca50120bf",
   "producedBy_samplingSite_location_h3_14": "8e3e6dca50120b7",
-  "last_modified_time":"2009-07-16T00:00:00Z"  
+  "last_modified_time":"2009-07-16T00:00:00Z"
 }
 """
     solr_dict = _try_to_add_solr_doc(core_doc_str)


### PR DESCRIPTION
Fix for the bug we discussed in standup this morning.  @datadavev FYI