### PR TITLE
This fixes the few records reindexing we kept seeing 

### DIFF
--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -500,7 +500,8 @@ def solr_max_source_updated_time(
         dict = res.json()
         docs = dict["response"]["docs"]
         if docs is not None and len(docs) > 0:
-            return dateparser.parse(docs[0]["sourceUpdatedTime"])
+            # Strip out the time zone since that is confusing matters
+            return dateparser.parse(docs[0]["sourceUpdatedTime"]).replace(tzinfo=None)
     except Exception:
         getLogger().error("Didn't get expected JSON back from %s when fetching max source updated time for %s", _url, authority_id)
 

--- a/isb_lib/core.py
+++ b/isb_lib/core.py
@@ -500,8 +500,7 @@ def solr_max_source_updated_time(
         dict = res.json()
         docs = dict["response"]["docs"]
         if docs is not None and len(docs) > 0:
-            # Strip out the time zone since that is confusing matters
-            return dateparser.parse(docs[0]["sourceUpdatedTime"]).replace(tzinfo=None)
+            return dateparser.parse(docs[0]["sourceUpdatedTime"])
     except Exception:
         getLogger().error("Didn't get expected JSON back from %s when fetching max source updated time for %s", _url, authority_id)
 

--- a/isb_web/sqlmodel_database.py
+++ b/isb_web/sqlmodel_database.py
@@ -278,7 +278,7 @@ def paged_things_with_ids(
     thing_select = _base_thing_select(authority, status, limit, offset, min_id)
 
     if min_time_created is not None:
-        thing_select = thing_select.filter(Thing.tcreated >= min_time_created)
+        thing_select = thing_select.filter(Thing.tcreated > min_time_created)
     thing_select = thing_select.order_by(Thing.primary_key.asc())
     return session.exec(thing_select).all()
 

--- a/tests/test_sqlmodel_database.py
+++ b/tests/test_sqlmodel_database.py
@@ -126,7 +126,7 @@ def test_paged_things_with_ids(session: Session):
     assert 1 == len(things_with_id)
     now = datetime.datetime.now()
     # Now add some stuff with the current date, and verify we don't get the old ones anymore
-    _add_some_things(session, 5, authority, now)
+    _add_some_things(session, 5, authority, now.replace(second=now.second + 1))
     things_with_tcreated = paged_things_with_ids(session, authority, 200, 10, 0, now, 0)
     assert 5 == len(things_with_tcreated)
     all_things = paged_things_with_ids(session, authority, 200, 100, 0, None, 0)


### PR DESCRIPTION
It's unclear to me that this is the right solution, but it does seem to do the trick.  I'm not sure if postgresql is omitting the tz, or if including the "Z" timezone affects the db filtering, but this works around the issue.

I'm hesitant to fully recommend taking the change because:

(1) The effects of reindexing are incredibly minor (extra CPU usage)
(2) It doesn't feel right -- the right solution feels like including the timezone in the database in the same way that solr is doing it (I think solr is including the Z)

@datadavev FYI, I leave this up to you to decide if you want it or not